### PR TITLE
Mouse sensitivity change when scoped

### DIFF
--- a/docs/userConfigReadme.md
+++ b/docs/userConfigReadme.md
@@ -11,14 +11,17 @@ The [`userconfig.Any` file](../data-files/userconfig.Any) is located in the [`da
 # User Table
 Each entry in the user table contains the following fields:
 
-* `id` a quick ID used to identify the user
-* `mouseDPI` the mouse DPI used for the player
-* `cmp360` the mouse sensitivity for the user (measured in cm/360°)
-* `reticleIndex` refers to which reticle this user prefers (if not required for the study)
-* `reticleScale` provides a range of reticle sizes over which to set the scale as an `Array` w/ 2 elements (min, max)
-* `reticleColor` provides a range of colors (as `Color4`) over which to set the reticle color as an `Array` w/ 2 elements (min, max)
-* `reticleShrinkTime` provides the time for the reticle to contract following a shot (in seconds)
-* `turnScale` provides a per-player motion scale, designed to compound with the experiment/session-level `turnScale`. By setting the X/Y of this `Vector2` to `-1` we can produce inversion for the controls on a per-player basis.
+|Field name           |Type     |Description                                                                                          |
+|---------------------|---------|-----------------------------------------------------------------------------------------------------|
+|`id`                 |`String` |A quick ID used to identify the user                                                                 |
+|`mouseDPI`           |`float`  |The mouse DPI used for the player (used for sensitivity adjustment)                                  |
+|`cmp360`             |`float`  |The mouse sensitivity for the user (measured in cm/360°)                                             |
+|`reticleIndex`       |`int`    |Refers to which reticle this user prefers (if not required for the study)                            |
+|`reticleScale`       |`float`  |Provides a range of reticle sizes over which to set the scale as an `Array` w/ 2 elements (min, max) | 
+|`reticleColor`       |`Color4` |Provides a range of colors over which to set the reticle color as an `Array` w/ 2 elements (min, max)|
+|`reticleShrinkTime`  |`float`  |Provides the time (in seconds) for the reticle to contract following a shot                          |
+|`turnScale`          |`Vector2(float)`|Provides a per-player view rotation/mouse sensitivity scale, designed to compound with the experiment/session-level `turnScale`. By setting the X/Y of this `Vector2` to `-1` we can produce inversion for the controls on a per-player basis.|
+|`scopeTurnScale`     |`Vector2(float)`|Provides an (optional) additional turn scale to apply when scoped. If this value is `Vector2(0,0)` (or unspecified) then a "default" scaling of the ratio of FoV (scoped vs unscoped) is used to scale mouse sensitivity |
 
 Refer to the [SAMPLEuserconfig.Any file](SAMPLE%20configs/SAMPLEuserconfig.Any) for an example of these settings.
 
@@ -53,6 +56,7 @@ users = [
         ];
         reticleShrinkTime = 1.0;            // Scale the reticle back to 50% over 1s after fire
         turnScale = Vector2(1.0, 1.0);      // This is the default condition (no turn scale) set to -1 for invert X/Y
+        scopeTurnScale = Vector2(0.0, 0.0); // This is the default condition (scoped turn scale based on ratio of scoped vs unscoped field of view)
     }, 
 ... 
 ```

--- a/source/App.cpp
+++ b/source/App.cpp
@@ -1430,7 +1430,7 @@ void App::drawHUD(RenderDevice *rd) {
 		hudFont->draw2D(rd, score_string, hudCenter + Vector2(125, 0) * scale, scale.x * sessConfig->hud.bannerSmallFontSize, Color3::white(), Color4::clear(), GFont::XALIGN_RIGHT, GFont::YALIGN_CENTER);
 	}
 }
-Vector2 App::scopedTurnScale(bool scoped = false, float FoV = 0.f) {
+Vector2 App::scopedTurnScale(bool scoped, float FoV) {
 	Vector2 baseTurnScale = getUserTurnScale();
 	// If we're not scoped just return the normal user turn scale
 	if (!scoped) return baseTurnScale;
@@ -1445,7 +1445,7 @@ Vector2 App::scopedTurnScale(bool scoped = false, float FoV = 0.f) {
 	}
 }
 
-void App::setScopeView(bool scoped = true) {
+void App::setScopeView(bool scoped) {
 	// Get player entity and calculate scope FoV
 	const shared_ptr<PlayerEntity>& player = scene()->typedEntity<PlayerEntity>("player");
 	const float scopeFoV = sessConfig->weapon.scopeFoV > 0 ? sessConfig->weapon.scopeFoV : sessConfig->render.hFoV;

--- a/source/App.cpp
+++ b/source/App.cpp
@@ -1174,13 +1174,6 @@ void App::setScopeView(bool scoped) {
 	player->turnScale = currentTurnScale();												// Scale sensitivity based on the field of view change here
 }
 
-/** Clear all targets one by one */
-void App::clearTargets() {
-	while (targetArray.size() > 0) {
-		destroyTarget(0);
-	}
-}
-
 void App::hitTarget(shared_ptr<TargetEntity> target) {
 	// Damage the target
 	float damage;

--- a/source/App.h
+++ b/source/App.h
@@ -165,11 +165,9 @@ protected:
 	void updateUser(void);
     void updateUserGUI();
 
-	/** Get the turn scale of this user */
-	Vector2 getUserTurnScale() { return sessConfig->player.turnScale * userTable.getCurrentUser()->turnScale;  }
-	/** Set the turn scale when scoped */
-	Vector2 scopedTurnScale(bool scoped = false, float FoV = 0.f);
-	/** Set the scoped view (and also adjust the turn scale) */
+	/** Get the current turn scale (per user and scope setting) */
+	Vector2 currentTurnScale();
+	/** Set the scoped view (and also adjust the turn scale), use setScopeView(!weapon->scoped()) to toggle scope */
 	void setScopeView(bool scoped = true);
 
 	void hitTarget(shared_ptr<TargetEntity>);

--- a/source/App.h
+++ b/source/App.h
@@ -12,6 +12,7 @@
 #include <G3D/G3D.h>
 #include "ConfigFiles.h"
 #include "TargetEntity.h"
+#include "PlayerEntity.h"
 #include "GuiElements.h"
 #include "PyLogger.h"
 #include "Weapon.h"
@@ -163,6 +164,22 @@ protected:
 	void loadDecals();
 	void updateUser(void);
     void updateUserGUI();
+
+	Vector2 getUserTurnScale() { return sessConfig->player.turnScale * userTable.getCurrentUser()->turnScale;  }
+	Vector2 fovTurnScale(float FoV) {
+		float ratioFoV = FoV / sessConfig->render.hFoV;
+		return ratioFoV * getUserTurnScale();
+	}
+
+	void setScopeView(bool scoped = true) {
+		// Get player entity and calculate scope FoV
+		const shared_ptr<PlayerEntity>& player = scene()->typedEntity<PlayerEntity>("player");	
+		const float scopeFoV = sessConfig->weapon.scopeFoV > 0 ? sessConfig->weapon.scopeFoV : sessConfig->render.hFoV;
+		m_weapon->setScoped(scoped);														// Update the weapon state		
+		const float FoV = (scoped ? scopeFoV : sessConfig->render.hFoV);					// Get new FoV in degrees (depending on scope state)
+		activeCamera()->setFieldOfView(FoV * pif() / 180.f, FOVDirection::HORIZONTAL);		// Set the camera FoV
+		player->turnScale = fovTurnScale(FoV);												// Scale sensitivity based on the field of view change here
+	}
 
 	void hitTarget(shared_ptr<TargetEntity>);
 	void simulateProjectiles(RealTime dt);

--- a/source/App.h
+++ b/source/App.h
@@ -165,21 +165,12 @@ protected:
 	void updateUser(void);
     void updateUserGUI();
 
+	/** Get the turn scale of this user */
 	Vector2 getUserTurnScale() { return sessConfig->player.turnScale * userTable.getCurrentUser()->turnScale;  }
-	Vector2 fovTurnScale(float FoV) {
-		float ratioFoV = FoV / sessConfig->render.hFoV;
-		return ratioFoV * getUserTurnScale();
-	}
-
-	void setScopeView(bool scoped = true) {
-		// Get player entity and calculate scope FoV
-		const shared_ptr<PlayerEntity>& player = scene()->typedEntity<PlayerEntity>("player");	
-		const float scopeFoV = sessConfig->weapon.scopeFoV > 0 ? sessConfig->weapon.scopeFoV : sessConfig->render.hFoV;
-		m_weapon->setScoped(scoped);														// Update the weapon state		
-		const float FoV = (scoped ? scopeFoV : sessConfig->render.hFoV);					// Get new FoV in degrees (depending on scope state)
-		activeCamera()->setFieldOfView(FoV * pif() / 180.f, FOVDirection::HORIZONTAL);		// Set the camera FoV
-		player->turnScale = fovTurnScale(FoV);												// Scale sensitivity based on the field of view change here
-	}
+	/** Set the turn scale when scoped */
+	Vector2 scopedTurnScale(bool scoped = false, float FoV = 0.f);
+	/** Set the scoped view (and also adjust the turn scale) */
+	void setScopeView(bool scoped = true);
 
 	void hitTarget(shared_ptr<TargetEntity>);
 	void simulateProjectiles(RealTime dt);

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -297,6 +297,7 @@ public:
     double			mouseDPI			= 800.0;						///< Mouse DPI setting
     double			cmp360				= 12.75;						///< Mouse sensitivity, reported as centimeters per 360�
 	Vector2			turnScale			= Vector2(1.0f, 1.0f);			///< Turn scale for player, can be used to invert controls in either direction
+	Vector2			scopeTurnScale		= Vector2(0.0f, 0.0f);			///< Scoped turn scale (0's imply default scaling)
 
 	int				currentSession		= 0;							///< Currently selected session
 		
@@ -324,6 +325,7 @@ public:
 			reader.getIfPresent("reticleColor", reticleColor);
 			reader.getIfPresent("reticleShrinkTime", reticleShrinkTimeS);
 			reader.getIfPresent("turnScale", turnScale);
+			reader.getIfPresent("scopeTurnScale", scopeTurnScale);
 			break;
         default:
             debugPrintf("Settings version '%d' not recognized in UserConfig.\n", settingsVersion);
@@ -343,6 +345,7 @@ public:
 		if (forceAll || def.reticleColor != reticleColor)				a["reticleColor"] = reticleColor;
 		if (forceAll || def.reticleShrinkTimeS != reticleShrinkTimeS)	a["reticleShrinkTime"] = reticleShrinkTimeS;
 		if (forceAll || def.turnScale != turnScale)						a["turnScale"] = turnScale;
+		if (forceAll || def.scopeTurnScale != scopeTurnScale)			a["scopeTurnScale"] = scopeTurnScale;
 		return a;
 	}
 };


### PR DESCRIPTION
These changes add support for changing mouse sensitivity when in scoped mode. There are 2 mechanisms to do this:

1.  By default the mouse sensitivity is scaled by the ratio of the (horizontal) scope field of view and the "normal" horizontal field of view. This results in a lower sensitivity when the scope field of view is reduced beyond the "normal" field of view.

2. The use can override the behavior above by specifying the `scopeTurnScale` in the `userconfig.Any` file. When this `Vector2` is not 0 length (i.e. not equal to `Vector2(0,0)`) the turn scale here applies (directly) when in scoped mode. Note that this compounds with the session config and player config `turnScale`s.