### PR TITLE
Add Parameter Logging for Sessions

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -111,6 +111,7 @@ As part of the general configuration parameters several controls over reporting 
 |`logFrameInfo`         |`bool` | Whether or not to log frame info into the `Frame_Info` table                     |
 |`logPlayerActions`     |`bool` | Whether or not to log player actions into the `Player_Action` table              |
 |`logTrialResponse`     |`bool` | Whether or not to log trial responses into the `Trials` table                    |
+|`sessParamsToLog`      |`Array<String>`| A list of additional parameter names (from the config) to log            |
 
 ```
 "logEnable" : true,
@@ -118,7 +119,15 @@ As part of the general configuration parameters several controls over reporting 
 "logFrameInfo": true,
 "logPlayerActions": true,
 "logTrialResponse": true,
+"sessParamsToLog" : [],
 ```
+
+### Logging Session Parameters
+The `sessParamsToLog` parameter allows the user to provide an additional list of parameter names to log into the `Sessions` table in the output database. This allows users to control their reporting of conditions on a per-session basis. These logging control can (of course) also be specified at the experiment level. For example, if we had a series of sessions over which the player's `moveRate` or the HUD's `showAmmo` value was changing we could add these to the `sessParamsToLog` array by specifying:
+```
+"sessParamsToLog" = ["moveRate", "showAmmo"],
+```
+In the top-level of the experiment config file. This allows the experiment designer to tag their sessions w/ relevant/changing parameters as needed for ease of reference later on from the database output file(s).
 
 ## Feedback Questions
 In addition to supporting in-app performance-based reporting the application also includes `.Any` configurable prompts that can be configured from the experiment or session level. Currently `MultipleChoice` and (text) `Entry` questions are supported, though more support could be added for other question types.

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1392,6 +1392,9 @@ public:
 	bool logTrialResponse		= true;		///< Log trial response in table?
 	bool logUsers				= true;		///< Log user infomration in table?
 
+	// Session parameter logging
+	Array<String> sessParamsToLog;			///< Parameter names to log to the Sessions table of the DB
+
 	void load(AnyTableReader reader, int settingsVersion = 1) {
 		switch (settingsVersion) {
 		case 1:
@@ -1401,6 +1404,7 @@ public:
 			reader.getIfPresent("logPlayerActions", logPlayerActions);
 			reader.getIfPresent("logTrialResponse", logTrialResponse);
 			reader.getIfPresent("logUsers", logUsers);
+			reader.getIfPresent("sessParamsToLog", sessParamsToLog);
 			break;
 		default:
 			throw format("Did not recognize settings version: %d", settingsVersion);
@@ -1416,6 +1420,7 @@ public:
 		if(forceAll || def.logPlayerActions != logPlayerActions)			a["logPlayerActions"] = logPlayerActions;
 		if(forceAll || def.logTrialResponse != logTrialResponse)			a["logTrialResponse"] = logTrialResponse;
 		if(forceAll || def.logUsers != logUsers)							a["logUsers"] = logUsers;
+		if(forceAll || def.sessParamsToLog != sessParamsToLog)				a["sessParamsToLog"] = sessParamsToLog;
 		return a;
 	}
 };

--- a/source/Logger.cpp
+++ b/source/Logger.cpp
@@ -79,7 +79,7 @@ void Logger::createResultsFile(const String& filename,
 	// Create any table to do lookup here
 	Any a = sessConfig->toAny(true);
 	// Add the looked up values
-	for (String name : sessConfig->logger.sessParamsToLog) { sessValues.append("'" + stringifyAny(a[name]) + "'"); }
+	for (String name : sessConfig->logger.sessParamsToLog) { sessValues.append("'" + a[name].unparse() + "'"); }
 	// add header row
 	insertRowIntoDB(m_db, "Sessions", sessValues);
 

--- a/source/Logger.cpp
+++ b/source/Logger.cpp
@@ -36,7 +36,10 @@ String Logger::genFileTimestamp() {
 	return String(timeStr);
 }
 
-void Logger::createResultsFile(String filename, String subjectID, String sessionID, String description)
+void Logger::createResultsFile(const String& filename, 
+	const String& subjectID, 
+	const shared_ptr<SessionConfig>& sessConfig, 
+	const String& description)
 {
 	// generate folder result_data if it does not exist.
 	if (!FileSystem::isDirectory(String("../results"))) {
@@ -62,15 +65,22 @@ void Logger::createResultsFile(String filename, String subjectID, String session
 			{ "subjectID", "text", "NOT NULL" },
 			{ "appendingDescription", "text"}
 	};
+	// add any user-specified parameters as headers
+	for (String name : sessConfig->logger.sessParamsToLog) { sessColumns.append({ "'" + name + "'", "text", "NOT NULL" }); }
 	createTableInDB(m_db, "Sessions", sessColumns); // no need of Primary Key for this table.
 
 	// populate table
 	RowEntry sessValues = {
-		"'" + sessionID + "'",
+		"'" + sessConfig->id + "'",
 		"'" + timeStr + "'",
 		"'" + subjectID + "'",
 		"'" + description + "'"
 	};
+	// Create any table to do lookup here
+	Any a = sessConfig->toAny(true);
+	// Add the looked up values
+	for (String name : sessConfig->logger.sessParamsToLog) { sessValues.append("'" + stringifyAny(a[name]) + "'"); }
+	// add header row
 	insertRowIntoDB(m_db, "Sessions", sessValues);
 
 	// 2. Targets
@@ -278,13 +288,20 @@ void Logger::loggerThreadEntry()
 	}
 }
 
-Logger::Logger(String filename, String subjectID, String sessionID, String description) : m_db(nullptr) {
-	// secure vector capacity large enough so as to avoid memory allocation time.
+Logger::Logger(const String& filename, 
+	const String& subjectID, 
+	const shared_ptr<SessionConfig>& sessConfig, 
+	const String& description 
+	) : m_db(nullptr) 
+{
+	// Reserve some space in these arrays here
 	m_playerActions.reserve(5000);
 	m_targetLocations.reserve(5000);
 	
-	createResultsFile(filename, subjectID,  sessionID, description);
+	// Create the results file
+	createResultsFile(filename, subjectID,  sessConfig, description);
 
+	// Thread management
 	m_running = true;
 	m_thread = std::thread(&Logger::loggerThreadEntry, this);
 }

--- a/source/Logger.h
+++ b/source/Logger.h
@@ -87,45 +87,6 @@ protected:
 	/** Close the results file */
 	void closeResultsFile(void);
 
-	static String stringifyAny(const Any& val) {
-		// Check to see if the simple parser handles this
-		String valStr = anyValToString(val);
-		if (!valStr.empty()) { return valStr; }
-		// Otherwise this is a more complicated type
-		switch (val.type()) {
-		case Any::ARRAY:
-			valStr = "[";
-			for (Any a : val.array()) {
-				String aStr = anyValToString(a);
-				if (aStr.empty()) { throw "Nested arrays not current supported for logging!"; }
-				valStr += aStr + ", ";
-			}
-			valStr = valStr.substr(0, valStr.length() - 2);
-			valStr += "]";
-			break;
-		case Any::TABLE:
-			throw "Any tables are currently not supported for logging!";
-			break;
-		default:
-			throw format("Unrecognized Any type: %s", val.type());
-			break;
-		}
-		return valStr;
-	}
-
-	static String anyValToString(const Any& val) {
-		switch (val.type()) {
-		case Any::BOOLEAN:
-			return val.boolean() ? "true" : "false";
-		case Any::NUMBER:
-			return String(std::to_string(val.number()));
-		case Any::STRING:
-			return val.string();
-		default:
-			return String();
-		}
-	}
-
 public:
 
 	Logger(const String& filename, const String& subjectID, const shared_ptr<SessionConfig>& sessConfig, const String& description);

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -86,7 +86,7 @@ void Session::onInit(String filename, String description) {
 		if (m_config->logger.enable) {
 			UserConfig user = *m_app->getCurrUser();
 			// Setup the logger and create results file
-			m_logger = Logger::create(filename, user.id, m_config->id, description);
+			m_logger = Logger::create(filename, user.id, m_config, description);
 			if (m_config->logger.logUsers) {
 				m_logger->logUserConfig(user, m_config->id, "start");
 			}


### PR DESCRIPTION
This pull request merges in changes affiliated with allowing the experiment designer to add a list of (self-referencing) parameter names from the config to write to the output database's `Sessions` table.