### PR TITLE
Improvements for bullet/explosion parametric control

### DIFF
--- a/docs/experimentConfigReadme.md
+++ b/docs/experimentConfigReadme.md
@@ -65,34 +65,48 @@ An example session configuration snippet is included below:
 ```
 
 ### Target Configuration
-* `targets` this target config table contains more detailed constraints for path generation for targets:
-    * `id` a short string to refer to this target information
-    * `respawnCount` is an integer providing the number of respawns to occur. For non-respawning items use `0` or leave unspecified.
-    * `visualSize` is a vector indicating the minimum ([0]) and maximum ([1]) visual size for the target (in deg)
-    * `speed` is a vector indictating the minimum ([0]) and maximum ([1]) speeds in angular velocity (in deg/s)
-    * `distance` is the distance to this target (in meters)
-    * `eccH/V` are controls for min ([0])/max([1]) horizontal/vertical eccentricity for target initial position (in deg)
-    * `motionChangePeriod` is a vector indicating the minimum ([0]) and maximum ([1]) motion change period allowed (in s)
-    * `upperHemisphereOnly` is a boolean flag indicating whether target flies only on the upper hemisphere of player-centric sphere. Only applicable to `FlyingEntity` defined in the "player" space.
-    * `logTargetTrajectory` is a boolean flag indicating whether or not this (individual) target's position should be logged for trials it is displayed for
-    * `jumpEnabled` determines whether the target can "jump" or not
-    * `jumpPeriod` is a vector indicating the minimum ([0]) and maximum ([1]) period to wait between jumps (in seconds)
-    * `jumpSpeed` is a vector indicating the minimum ([0]) and maximum([1]) angular speed with which to jump (in deg/s)
-    * `accelGravity` is the min ([0])/max ([1]) acceleration due to gravity during the jump (in m/s^2)
-    * `modelSpec` is an `Any` that constructs an `ArticulatedModel` similar to that used in the [the weapon config readme](weaponConfigReadme.md). For now this spec needs to point to an `obj` file with a model named `core/icosahedron_default`.
-    * `destinations` is an array of `Destination` types each of which contains:
-      * `t` the time (in seconds) for this point in the path
-      * `xyz` the position for this point in the path
-    * `destSpace` the space for which the target is rendered (useful for non-destiantion based targets, "player" or "world")
-    * `spawnBounds` specifies an axis-aligned bounding box (`G3D::AABox`) to specify the bounds for the target's spawn location in cases where `destSpace="world"` and the target is not destination-based. For more information see the [section below on serializing bounding boxes](##-Bounding-Boxes-(`G3D::AABox`-Serialization)).
-    * `moveBounds` specifies an axis-aligned bounding box (`G3D::AABox`) to specify the bounds for target motion in cases where `destSpace="world"` and the target is not destination-based. For more information see the [section below on serializing bounding boxes](##-Bounding-Boxes-(`G3D::AABox`-Serialization)).
-    * `axisLocked` is a boolean array specifying which (if any) axes of motion are "locked" (i.e. disallowed) for this target's motion in [X,Y,Z] order. This only applies for world-space, parametric targets.
-    * `hitSound` is a filename for the sound to play when the target is hit but not destroyed.
-    * `hitSoundVol` provides the volume (as a float) for the hit sound to be played at (default is `1.0`).
-    * `destroyedSound` is a filename for the sound to play when the target is both hit and destroyed.
-    * `destroyedSoundVol` provides the volume (as a float) for the destroyed sound to be played at (default is `10.0`).
-    * `destroyDecal` the decal to show when destroyed
-    * `destroyDecalScale` a scale to apply the the destroy decal
+The `targets` array specifies a list of targets each of which can contain any/all of the following parameters. The following sections provide a more detailed breakdown of target parameters by group.
+
+#### Basic Configuration 
+The following configuration is universal to all target types.
+
+* `id` a short string to refer to this target information
+* `respawnCount` is an integer providing the number of respawns to occur. For non-respawning items use `0` or leave unspecified.
+* `visualSize` is a vector indicating the minimum ([0]) and maximum ([1]) visual size for the target (in deg)
+* `destSpace` the space for which the target is rendered (useful for non-destiantion based targets, "player" or "world")
+* `hitSound` is a filename for the sound to play when the target is hit but not destroyed.
+* `hitSoundVol` provides the volume (as a float) for the hit sound to be played at (default is `1.0`).
+* `destroyedSound` is a filename for the sound to play when the target is both hit and destroyed.
+* `destroyedSoundVol` provides the volume (as a float) for the destroyed sound to be played at (default is `10.0`).
+* `destroyDecal` the decal to show when destroyed
+* `destroyDecalScale` a scale to apply the the destroy decal (may be decal dependent)
+* `destroyDecalDuration` is the duration to
+* `modelSpec` is an `Any` that constructs an `ArticulatedModel` similar to that used in the [the weapon config readme](weaponConfigReadme.md). For now this spec needs to point to an `obj` file with a model named `core/icosahedron_default`.
+
+#### Player-space (Parametric) Targets
+The following configuration only applies to player-bound parametric targets.
+
+* `speed` is a vector indictating the minimum ([0]) and maximum ([1]) speeds in angular velocity (in deg/s)
+* `distance` is the distance to this target (in meters)
+* `eccH/V` are controls for min ([0])/max([1]) horizontal/vertical eccentricity for target initial position (in deg)
+* `motionChangePeriod` is a vector indicating the minimum ([0]) and maximum ([1]) motion change period allowed (in s)
+* `upperHemisphereOnly` is a boolean flag indicating whether target flies only on the upper hemisphere of player-centric sphere. Only applicable to `FlyingEntity` defined in the "player" space.
+* `logTargetTrajectory` is a boolean flag indicating whether or not this (individual) target's position should be logged for trials it is displayed for
+* `jumpEnabled` determines whether the target can "jump" or not
+* `jumpPeriod` is a vector indicating the minimum ([0]) and maximum ([1]) period to wait between jumps (in seconds)
+* `jumpSpeed` is a vector indicating the minimum ([0]) and maximum([1]) angular speed with which to jump (in deg/s)
+* `accelGravity` is the min ([0])/max ([1]) acceleration due to gravity during the jump (in m/s^2)
+
+#### World-space Target Specific Configuration
+The following configuration parameters are specific to world-space targets:
+
+* `destinations` is an array of `Destination` types each of which contains:
+    * `t` the time (in seconds) for this point in the path
+    * `xyz` the position for this point in the path
+* `spawnBounds` specifies an axis-aligned bounding box (`G3D::AABox`) to specify the bounds for the target's spawn location in cases where `destSpace="world"` and the target is not destination-based. For more information see the [section below on serializing bounding boxes](##-Bounding-Boxes-(`G3D::AABox`-Serialization)).
+* `moveBounds` specifies an axis-aligned bounding box (`G3D::AABox`) to specify the bounds for target motion in cases where `destSpace="world"` and the target is not destination-based. For more information see the [section below on serializing bounding boxes](##-Bounding-Boxes-(`G3D::AABox`-Serialization)).
+* `axisLocked` is a boolean array specifying which (if any) axes of motion are "locked" (i.e. disallowed) for this target's motion in [X,Y,Z] order. This only applies for world-space, parametric targets.
+
 
 #### Target Configuration Example
 An example target configuration snippet is provided below:
@@ -113,6 +127,7 @@ targets = [
         "destroyedSoundVol" : 10.0f,            // Volume to play destroyed sound at
         "destroyDecal" : "explosion_01.png",    // Use default explosion decal
         "destroyDecalScale" : 1.0,              // Use default sizing
+        "destroyDecalDuration" : 0.1,           // Show the decal for 0.1s (default)
     },
     {
         "id": "world-space paramtetric",

--- a/docs/experimentConfigReadme.md
+++ b/docs/experimentConfigReadme.md
@@ -91,6 +91,8 @@ An example session configuration snippet is included below:
     * `hitSoundVol` provides the volume (as a float) for the hit sound to be played at (default is `1.0`).
     * `destroyedSound` is a filename for the sound to play when the target is both hit and destroyed.
     * `destroyedSoundVol` provides the volume (as a float) for the destroyed sound to be played at (default is `10.0`).
+    * `destroyDecal` the decal to show when destroyed
+    * `destroyDecalScale` a scale to apply the the destroy decal
 
 #### Target Configuration Example
 An example target configuration snippet is provided below:
@@ -99,31 +101,33 @@ An example target configuration snippet is provided below:
 targets = [
     {
         "id": "simple_target",
-        "destSpace" : "player",             // This is a player-centered-spherical-space target
-        "visualSize" : [0.5, 0.5],          // 0.5m size
-        "respawnCount" : 0,                 // Don't respawn
-        "speed": [1.0, 3.0],                // 1-3m/s speed
-        "eccH" : [5.0, 15.0],               // 5-15° initial spawn location (horizontal)
-        "eccV" : [0.0, 5.0],                // 0-5° intitial spawn location (vertical)
+        "destSpace" : "player",                 // This is a player-centered-spherical-space target
+        "visualSize" : [0.5, 0.5],              // 0.5m size
+        "respawnCount" : 0,                     // Don't respawn
+        "speed": [1.0, 3.0],                    // 1-3m/s speed
+        "eccH" : [5.0, 15.0],                   // 5-15° initial spawn location (horizontal)
+        "eccV" : [0.0, 5.0],                    // 0-5° intitial spawn location (vertical)
         "hitSound" : "sound/18397__inferno__smalllas.wav",      // Sound to play when target hit
-        "hitSoundVol" : 1.0,                // Volume to play the hit sound at
+        "hitSoundVol" : 1.0,                    // Volume to play the hit sound at
         "destroyedSound" : "sound/32882__Alcove_Audio__BobKessler_Metal_Bangs-1.wav", // Sound to play when target destroyed (explosion)
-        "destroyedSoundVol" : 10.0f,        // Volume to play destroyed sound at
+        "destroyedSoundVol" : 10.0f,            // Volume to play destroyed sound at
+        "destroyDecal" : "explosion_01.png",    // Use default explosion decal
+        "destroyDecalScale" : 1.0,              // Use default sizing
     },
     {
         "id": "world-space paramtetric",
-        "destSpace" : "world",              // This is a world-space target
+        "destSpace" : "world",                  // This is a world-space target
         "bounds" : AABox {
-                Point3(-8.5, 0.5, -11.5),   // It is important these are specified in "increasing order"
-                Point3(-6.5, 1.5, -7.5)     // All x,y,z coordinates must be greater than those above
+                Point3(-8.5, 0.5, -11.5),       // It is important these are specified in "increasing order"
+                Point3(-6.5, 1.5, -7.5)         // All x,y,z coordinates must be greater than those above
         },
         "axisLocked": [true, false, false],
-        "visualSize" : [0.3, 1.0],          // Visual size between 0.3-1m
-        "respawnCount" : -1,                // Respawn forever
+        "visualSize" : [0.3, 1.0],              // Visual size between 0.3-1m
+        "respawnCount" : -1,                    // Respawn forever
     },
     {
         "id" : "destination-based",
-        "destSpace" : "world",              // Important this is specified here
+        "destSpace" : "world",                  // Important this is specified here
         "destinations" : {
             {"t": 0.0, "xyz": Vector3(0.00, 0.00, 0.00)},
             {"t": 0.1, "xyz": Vector3(0.00, 1.00, 0.00)},
@@ -131,7 +135,7 @@ targets = [
             {"t": 10.2, "xyz": Vector3(10.1, 1.01, -100.3)}
         },
     },
-    #include("example_target.Any"),         // Example of including an external .Any file
+    #include("example_target.Any"),             // Example of including an external .Any file
 ],
 ```
 

--- a/docs/weaponConfigReadme.md
+++ b/docs/weaponConfigReadme.md
@@ -97,7 +97,7 @@ Controls specific to the miss decals drawn in the scene are included below:
     "hitDecalColorMult" = 2.0;                      // Slightly emissive hit decal
 ```
 
-## Muzzle Flash Control
+<!-- ## Muzzle Flash Control
 Controls specific to muzzle flash are provided below:
 
 | Parameter Name        |Units      | Description                                                                                           |
@@ -108,7 +108,7 @@ Controls specific to muzzle flash are provided below:
 ```
     "renderMuzzleFlash" : false;                // Don't render a muzzle flash
     "muzzleOffset" : Vector3(0,0,0);            // No muzzle offset
-```
+``` -->
 
 ## Scope Control
 Controls specific to scope behavior are provided below:

--- a/docs/weaponConfigReadme.md
+++ b/docs/weaponConfigReadme.md
@@ -17,15 +17,23 @@ As an example of this concept, you **cannot** (currently) specify a weapon at th
 
 # Weapon Config Field Descriptions
 
-This file provides information about the weapon to be used in the experiment. Detailed field descriptions are provided below.
+This file provides information about the weapon to be used in the experiment. Detailed field descriptions are provided below. Each example configuration provides the default values for it's fields.
 
 | Parameter Name        |Units      | Description                                                                                           |
 |-----------------------|-----------|-------------------------------------------------------------------------------------------------------|
 |`maxAmmo`              |shots      | The maximum number of clicks a user can make in any given trial                                       |
 |`firePeriod`           |s/shot     | The minimum fire period allowed in the session (set this to 0 if you want "laser" mode)               |
-|`autoFire`             |bool       | Whether or not the weapon fires when the left mouse is held, or requires release between fire         |
+|`autoFire`             |`bool`     | Whether or not the weapon fires when the left mouse is held, or requires release between fire         |
 |`damagePerSecond`      |damage/s   | The damage done by the weapon per second, when `firePeriod` > 0 the damage per round is set by `damagePerSecond`*`firePeriod`, when `firePeriod` is 0 and `autoFire` is `True` damage is computed based on time hitting the target.        |
-|`hitScan`              |bool       | Whether or not the weapon acts as an instantaneous hitscan (true) vs propagated projectile (false)    |
+|`hitScan`              |`bool`     | Whether or not the weapon acts as an instantaneous hitscan (true) vs propagated projectile (false)    |
+
+```
+    "maxAmmo" : 10000;              // Large ammo count
+    "firePeriod" : 0.5;             // 2 shots per second fire period
+    "autoFire": false;              // Single fire (no hold to fire)
+    "damagePerSecond": 2.0;         // 1 damage per shot (single shot to destroy)
+    "hitScan" : true;               // Use hitscan (not propogated projectile) for hit detection
+```
 
 ## Sound and View Model
 Controls specific to the sound/view model for the weapon are provided below:
@@ -34,31 +42,60 @@ Controls specific to the sound/view model for the weapon are provided below:
 |-----------------------|-----------|-------------------------------------------------------------------------------------------------------|
 |`fireSound`            |file       | The filename/location of the audio clip to use for the weapon firing                                  |
 |`fireSoundVol`         |ratio      | The volume to play the `fireSound` clip with                                                          |
-|`renderModel`          |bool       | Whether or not a weapon model is rendered in the first-person view                                    |
+|`renderModel`          |`bool`     | Whether or not a weapon model is rendered in the first-person view                                    |
 |`modelSpec`            |`ArticulatedModel::Specification` | Any-based specification for the weapon being used                              |
+
+```
+    "fireSound" : "sound/42108__marcuslee__Laser_Wrath_6.wav"           // This comes w/ G3D
+    "fireSoundVol" : 0.5;       // Play the fire sound at 1/2 volume
+    "renderModel" : false;      // Don't render a weapon model
+    "modelSpec" : [];           // No default model spec provided (see the example config below for more info)
+```
 
 ## Projectiles 
 Controls specific to the projectiles fired by the weapon are included below:
 
 | Parameter Name        |Units      | Description                                                                                           |
 |-----------------------|-----------|-------------------------------------------------------------------------------------------------------|
-|`renderBullets`        |bool       | Whether or not bullets are rendered from the barrel of the weapon when fired                          |
+|`renderBullets`        |`bool`     | Whether or not bullets are rendered from the barrel of the weapon when fired                          |
 |`bulletSpeed`          |m/s        | The speed of rendered bullets                                                                         |
 |`bulletGravity`        |m/s²       | The gravity to apply to bullets (0 for no droop)                                                      |
+|`bulletScale`          |`Vector3(`m`)`| This sets the scaling to apply to the bullet (effectively controls bullet size in meters)        |
+|`bulletColor`          |`Color3`   | The (emissive) color/power to apply to the bullet. RGB fields can be > 1                              |
+|`bulletOffset`         |`Vector3(`m`)`| The offset from the camera view to where to spawn a bullet                                       |
+
+```
+    "renderBullets" : false;                        // Don't draw bullets
+    "bulletSpeed" : 100.0;                          // 100m/s bullet speed (not used)
+    "bulletGravity" : 0.0;                          // No bullet gravity
+    "bulletScale" : Vector3(0.05, 0.05, 2.0);       // 5cm x 5cm x 2m bullet shape
+    "bulletColor": Color3(5, 4, 0);                 // Emissive yellow-ish projectile
+    "bulletOffset" : Vector3(0, 0, 0);              // No bullet offset from the camera
+```
 
 ## Decal Control
 Controls specific to the miss decals drawn in the scene are included below:
 
 | Parameter Name        |Units      | Description                                                                                           |
 |-----------------------|-----------|-------------------------------------------------------------------------------------------------------|
-|`renderDecals`         |bool       | Whether or not bullet hole decals are put on misses when `autoFire` is `False` and `firePeriod` > 0 (i.e. not in laser mode) |
-|`missDecal`            |String     | The filename of an image to use for miss decals. Can be set to `""` for no decals.
-|`missDecalCount`       |int        | The maximum number of miss decals to draw from this weapon (oldest are removed first). Can be set to `0` for no decals.|
-|`missDecalScale`       |float      | A scale to apply to the miss decals drawn by this weapon, `1.0` means do not scale                     |
-|`hitDecal`             |String     | The filename of an image to use for hit decals. Can be set to `""` for no decals.                      |
-|`hitDecalScale`        |float      | A scale to apply to the hit decals drawn by this weapon. `1.0` means do not scale.                     |
+|`renderDecals`         |`bool`     | Whether or not bullet hole decals are put on misses when `autoFire` is `False` and `firePeriod` > 0 (i.e. not in laser mode) |
+|`missDecal`            |`String`   | The filename of an image to use for miss decals. Can be set to `""` for no decals.
+|`missDecalCount`       |`int`      | The maximum number of miss decals to draw from this weapon (oldest are removed first). Can be set to `0` for no decals.|
+|`missDecalScale`       |`float`    | A scale to apply to the miss decals drawn by this weapon, `1.0` means do not scale                     |
+|`hitDecal`             |`String`   | The filename of an image to use for hit decals. Can be set to `""` for no decals.                      |
+|`hitDecalScale`        |`float`    | A scale to apply to the hit decals drawn by this weapon. `1.0` means do not scale.                     |
 |`hitDecalDuration`     |s          | The duration to draw a hit decal for (in seconds).                                                     |
-|`hitDecalColorMult`    |float      | The value used to multiply colors for the hit decal (higher means brighter). Set >1 for "emissive".    |
+|`hitDecalColorMult`    |`float`    | The value used to multiply colors for the hit decal (higher means brighter). Set >1 for "emissive".    |
+
+```
+    "renderDecals" : true,                          // Draw decals on hit/miss
+    "missDecal" : "bullet-decal-256x256.png";       // Included in FPSci
+    "missDecalCount" : 2;                           // Number of miss decals to draw (at once)
+    "missDecalScale" : 1.0;                         // Don't scale the miss decal (1.0x scale)
+    "hitDecalScale" : 1.0;                          // Don't scale the hit decal  (1.0x scale)
+    "hitDecalDurationS" : 0.1;                      // Draw the decal for 0.1s
+    "hitDecalColorMult" = 2.0;                      // Slightly emissive hit decal
+```
 
 ## Muzzle Flash Control
 Controls specific to muzzle flash are provided below:
@@ -68,6 +105,11 @@ Controls specific to muzzle flash are provided below:
 |`renderMuzzleFlash`    |bool       | Whether or not a muzzle flash is rendered for the weapon                                              |
 |`muzzleOffset`         |`Vector3`(m)| The offset of the muzzle within the weapon frame                                                     |
 
+```
+    "renderMuzzleFlash" : false;                // Don't render a muzzle flash
+    "muzzleOffset" : Vector3(0,0,0);            // No muzzle offset
+```
+
 ## Scope Control
 Controls specific to scope behavior are provided below:
 
@@ -75,6 +117,11 @@ Controls specific to scope behavior are provided below:
 |-----------------------|-----------|-------------------------------------------------------------------------------------------------------|
 |`scopeFoV`             |float      | (Horizontal) field of view for the camera when using a scope (set to `0` for no scope)                |
 |`scopeToggle`          |bool       | Whether or not the scope is active when the keymapped button is held (false) or toggled using this button (true)|
+
+```
+    "scopeFoV" : 0.0;                           // Don't change FoV w/ scope
+    "scopeToggle" : false;                      // Don't use scope "toggling" mode (requiresl hold)
+```
 
 # Example Config
 The config below provides an example for each of the fields above (along with their default values):

--- a/source/App.cpp
+++ b/source/App.cpp
@@ -168,12 +168,16 @@ void App::loadModels() {
 	}
 
 	// Add all the unqiue targets to this list
-	Table<String, Any> toBuild;
+	Table<String, Any> targetsToBuild;
+	Table<String, String> explosionsToBuild;
+	Table<String, float> explosionScales;
 	for (TargetConfig target : experimentConfig.targets) {
-		toBuild.set(target.id, target.modelSpec);
+		targetsToBuild.set(target.id, target.modelSpec);
+		explosionsToBuild.set(target.id, target.destroyDecal);
+		explosionScales.set(target.id, target.destroyDecalScale);
 	}
 	// Append the basic model automatically (used for reference targets for now)
-	toBuild.set("reference", PARSE_ANY(ArticulatedModel::Specification{
+	targetsToBuild.set("reference", PARSE_ANY(ArticulatedModel::Specification{
 		filename = "model/target/target.obj";
 		cleanGeometrySettings = ArticulatedModel::CleanGeometrySettings{
 					allowVertexMerging = true;
@@ -185,47 +189,46 @@ void App::loadModels() {
 					maxSmoothAngleDegrees = 0;
 		};
 	}));
-
-	// Setup the explosion specification
-	Any explosionSpec = PARSE_ANY(ArticulatedModel::Specification{
-		filename = "ifs/square.ifs";
-		preprocess = {
-			transformGeometry(all(), Matrix4::scale(0.1, 0.1, 0.1));
-			//scaleAndOffsetTexCoord0(all(), 0.0769, 0);
-			setMaterial(all(), UniversalMaterial::Specification{
-				lambertian = Texture::Specification {
-					//filename = "explosion_01_strip13.png";
-					filename = "explosion_01.png";
-					encoding = Color3(1, 1, 1);
-				};
-			});
-		}; 
-	});
-	for (int i = 0; i < modelScaleCount; i++) {
-		const float scale = pow(1.0f + TARGET_MODEL_ARRAY_SCALING, float(i) - TARGET_MODEL_ARRAY_OFFSET);
-		explosionSpec.set("scale", scale*20.0f);
-		m_explosionModels.push(ArticulatedModel::create(explosionSpec));
-	}
+	explosionsToBuild.set("reference", "explosion_01.png");
+	explosionScales.set("reference", 1.0);
 
 	// Scale the models into the m_targetModel table
-	for (String id : toBuild.getKeys()) {
-		// Get the any spec
-		Any spec = toBuild.get(id);
+	for (String id : targetsToBuild.getKeys()) {
+		// Get the any specs
+		Any tSpec = targetsToBuild.get(id);
+		Any explosionSpec = Any::parse(format(
+			"ArticulatedModel::Specification {\
+				filename = \"ifs/square.ifs\";\
+				preprocess = {\
+					transformGeometry(all(), Matrix4::scale(0.1, 0.1, 0.1));\
+					setMaterial(all(), UniversalMaterial::Specification{\
+						lambertian = Texture::Specification {\
+							filename = \"%s\";\
+							encoding = Color3(1, 1, 1);\
+						};\
+					});\
+				};\
+			}", explosionsToBuild.get(id).c_str()));
+
 		// Get the bounding box to scale to size rather than arbitrary factor
-		shared_ptr<ArticulatedModel> size_model = ArticulatedModel::create(ArticulatedModel::Specification(spec));
+		shared_ptr<ArticulatedModel> size_model = ArticulatedModel::create(ArticulatedModel::Specification(tSpec));
 		AABox bbox;
 		size_model->getBoundingBox(bbox);
 		Vector3 extent = bbox.extent();
 		logPrintf("%20s bounding box: [%2.2f, %2.2f, %2.2f]\n", id.c_str(), extent[0], extent[1], extent[2]);
-		float default_scale = 1.0f / extent[0];					// Setup scale so that default model is 1m across
+		const float default_scale = 1.0f / extent[0];					// Setup scale so that default model is 1m across
 
-		Array<shared_ptr<ArticulatedModel>> models;
+		// Create the target/explosion models for this target
+		Array<shared_ptr<ArticulatedModel>> tModels, expModels;
 		for (int i = 0; i <= modelScaleCount; ++i) {
 			const float scale = pow(1.0f + TARGET_MODEL_ARRAY_SCALING, float(i) - TARGET_MODEL_ARRAY_OFFSET);
-			spec.set("scale", scale*default_scale);
-			models.push(ArticulatedModel::create(spec));
+			tSpec.set("scale", scale*default_scale);
+			explosionSpec.set("scale", (20.0 * scale * explosionScales.get(id)));
+			tModels.push(ArticulatedModel::create(tSpec));
+			expModels.push(ArticulatedModel::create(explosionSpec));
 		}
-		targetModels.set(id, models);
+		targetModels.set(id, tModels);
+		m_explosionModels.set(id, expModels);
 	}
 
 	// Create a series of colored materials to choose from for target health
@@ -1212,10 +1215,16 @@ void App::hitTarget(shared_ptr<TargetEntity> target) {
 
 	}
 	else if (target->health() <= 0) {
-		// create explosion animation
+		// Position explosion
 		CFrame explosionFrame = target->frame();
 		explosionFrame.rotation = activeCamera()->frame().rotation;
-		const shared_ptr<VisibleEntity> newExplosion = VisibleEntity::create(format("explosion%d", m_explosionIdx), scene().get(), m_explosionModels[target->scaleIndex()], explosionFrame);
+		// Create the explosion
+		const shared_ptr<VisibleEntity> newExplosion = VisibleEntity::create(
+			format("explosion%d", m_explosionIdx), 
+			scene().get(), 
+			m_explosionModels.get(target->id())[target->scaleIndex()], 
+			explosionFrame
+		);
 		m_explosionIdx++;
 		m_explosionIdx %= m_maxExplosions;
 		scene()->insert(newExplosion);

--- a/source/App.cpp
+++ b/source/App.cpp
@@ -788,13 +788,13 @@ void App::onSimulation(RealTime rdt, SimTime sdt, SimTime idt) {
 	simulateProjectiles(sdt);
 
 	// explosion animation
-	const RealTime now = System::time();
 	for (int i = 0; i < m_explosions.size(); i++) {
 		shared_ptr<VisibleEntity> explosion = m_explosions[i];
-		if (m_explosionEndTimes[i] < now) {
+		m_explosionRemainingTimes[i] -= sdt;
+		if (m_explosionRemainingTimes[i] <= 0) {
 			scene()->remove(explosion);
 			m_explosions.fastRemove(i);
-			m_explosionEndTimes.fastRemove(i);
+			m_explosionRemainingTimes.fastRemove(i);
 			i--;
 		}
 		else {
@@ -1229,7 +1229,7 @@ void App::hitTarget(shared_ptr<TargetEntity> target) {
 		m_explosionIdx %= m_maxExplosions;
 		scene()->insert(newExplosion);
 		m_explosions.push(newExplosion);
-		m_explosionEndTimes.push(System::time() + 0.1f); // make explosion end in 0.5 seconds
+		m_explosionRemainingTimes.push(experimentConfig.getTargetConfigById(target->id())->destroyDecalDuration); // Schedule end of explosion
 		target->playDestroySound();
 
 		sess->countDestroy();

--- a/source/App.cpp
+++ b/source/App.cpp
@@ -732,7 +732,8 @@ void App::simulateProjectiles(RealTime dt) {
 			if (closest < hitThreshold) {
 				hitTarget(closestTarget);
 				// Offset position slightly along normal to avoid Z-fighting the target
-				drawDecal(info.point + 0.01 * info.normal, activeCamera()->frame().lookVector(), true);
+				const Vector3& camDir = -activeCamera()->frame().lookVector();
+				drawDecal(info.point + 0.01 * camDir, camDir, true);
 				projectile.clearRemainingTime();
 			}
 			// Handle (miss) decals here

--- a/source/App.h
+++ b/source/App.h
@@ -106,7 +106,7 @@ protected:
 	Array<shared_ptr<VisibleEntity>>		m_currentMissDecals;				///< Pointers to miss decals
 
 	Array<shared_ptr<VisibleEntity>>		m_explosions;						///< Model for target destroyed decal
-	Array<RealTime>							m_explosionEndTimes;				///< Time for end of explosion
+	Array<RealTime>							m_explosionRemainingTimes;			///< Time for end of explosion
 	int										m_explosionIdx = 0;					///< Explosion index
 	const int								m_maxExplosions = 20;				///< Maximum number of simultaneous explosions
 		

--- a/source/App.h
+++ b/source/App.h
@@ -122,7 +122,7 @@ protected:
 	shared_ptr<RenderControls>				m_renderControls;
 	shared_ptr<WeaponControls>				m_weaponControls;
 
-	Array<shared_ptr<ArticulatedModel>>		m_explosionModels;
+	Table<String, Array<shared_ptr<ArticulatedModel>>> m_explosionModels;
 
 	/** Used for visualizing history of frame times. Temporary, awaiting a G3D built-in that does this directly with a texture. */
 	Queue<float>							m_frameDurationQueue;				///< Queue for history of frrame times

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -651,8 +651,8 @@ public:
 	bool	renderModel = false;										///< Render a model for the weapon?
 	bool	hitScan = true;												///< Is the weapon a projectile or hitscan
 
-	Vector3	muzzleOffset = Vector3(0, 0, 0);							///< Offset to the muzzle of the weapon model
-	bool	renderMuzzleFlash = false;									///< Render a muzzle flash when the weapon fires?
+	//Vector3	muzzleOffset = Vector3(0, 0, 0);							///< Offset to the muzzle of the weapon model
+	//bool	renderMuzzleFlash = false;									///< Render a muzzle flash when the weapon fires?
 
 	bool	renderBullets = false;										///< Render bullets leaving the weapon
 	float	bulletSpeed = 100.0f;										///< Speed to draw at for rendered rounds (in m/s)
@@ -711,8 +711,8 @@ public:
 				reader.getIfPresent("modelSpec", modelSpec);
 			}
 			
-			reader.getIfPresent("muzzleOffset", muzzleOffset);
-			reader.getIfPresent("renderMuzzleFlash", renderMuzzleFlash);
+			//reader.getIfPresent("muzzleOffset", muzzleOffset);
+			//reader.getIfPresent("renderMuzzleFlash", renderMuzzleFlash);
 
 			reader.getIfPresent("renderBullets", renderBullets);
 			reader.getIfPresent("bulletSpeed", bulletSpeed);
@@ -758,8 +758,8 @@ public:
 		if (forceAll || def.renderModel != renderModel)						a["renderModel"] = renderModel;
 		if (forceAll || !(def.modelSpec == modelSpec))						a["modelSpec"] = modelSpec;
 
-		if (forceAll || def.muzzleOffset != muzzleOffset)					a["muzzleOffset"] = muzzleOffset;
-		if (forceAll || def.renderMuzzleFlash != renderMuzzleFlash)			a["renderMuzzleFlash"] = renderMuzzleFlash;
+		//if (forceAll || def.muzzleOffset != muzzleOffset)					a["muzzleOffset"] = muzzleOffset;
+		//if (forceAll || def.renderMuzzleFlash != renderMuzzleFlash)			a["renderMuzzleFlash"] = renderMuzzleFlash;
 
 		if (forceAll || def.renderBullets != renderBullets)					a["renderBullets"] = renderBullets;
 		if (forceAll || def.bulletSpeed != bulletSpeed)						a["bulletSpeed"] = bulletSpeed;
@@ -782,7 +782,6 @@ public:
 		if (forceAll || def.damageRollOffDistance != damageRollOffDistance)	a["damageRollOffDistance"] = damageRollOffDistance;
 		if (forceAll || def.scopeFoV != scopeFoV)							a["scopeFoV"] = scopeFoV;
 		if (forceAll || def.scopeToggle != scopeToggle)						a["scopeToggle"] = scopeToggle;
-
 
 		return a;
 	}

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -814,6 +814,7 @@ public:
 
 	String			destroyDecal = "explosion_01.png";		///< Decal to use for destroy event
 	float			destroyDecalScale = 1.0;				///< Scale to apply to destroy (relative to target size)
+	RealTime		destroyDecalDuration = 0.1;				///< Destroy decal display duration
 
 	String			hitSound = "sound/18397__inferno__smalllas.wav";	///< Sound to play when target is hit (but not destoyed)
 	float			hitSoundVol = 1.0f;						///< Hit sound volume
@@ -861,6 +862,7 @@ public:
 
 			reader.getIfPresent("destroyDecal", destroyDecal);
 			reader.getIfPresent("destroyDecalScale", destroyDecalScale);
+			reader.getIfPresent("destroyDecalDuration", destroyDecalDuration);
 			
 			reader.getIfPresent("destSpace", destSpace);
 			reader.getIfPresent("destinations", destinations);
@@ -929,6 +931,7 @@ public:
 
 		if(forceAll || def.destroyDecal != destroyDecal)						a["destroyDecal"] = destroyDecal;
 		if(forceAll || def.destroyDecalScale != destroyDecalScale)				a["destroyDecalScale"] = destroyDecalScale;
+		if (forceAll || def.destroyDecalDuration != destroyDecalDuration)		a["destroyDecalDuration"] = destroyDecalDuration;
 
 		if(forceAll || def.hitSound != hitSound)								a["hitSound"] = hitSound;
 		if(forceAll || def.hitSoundVol != hitSoundVol)							a["hitSoundVol"] = hitSoundVol;

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -657,6 +657,9 @@ public:
 	bool	renderBullets = false;										///< Render bullets leaving the weapon
 	float	bulletSpeed = 100.0f;										///< Speed to draw at for rendered rounds (in m/s)
 	float	bulletGravity = 0.0f;										///< Gravity to use for bullets (default is no droop)
+	Vector3 bulletScale = Vector3(0.05f, 0.05f, 2.f);					///< Scale to use on bullet object
+	Color3  bulletColor = Color3(5, 4, 0);								///< Color/power for bullet emissive texture
+	Vector3 bulletOffset = Vector3(0,0,0);								///< Offset to start the bullet from (along the look direction)
 	
 	bool	renderDecals = true;										///< Render decals when the shots miss?
 	String	missDecal = "bullet-decal-256x256.png";						///< The decal to place where the shot misses
@@ -714,6 +717,9 @@ public:
 			reader.getIfPresent("renderBullets", renderBullets);
 			reader.getIfPresent("bulletSpeed", bulletSpeed);
 			reader.getIfPresent("bulletGravity", bulletGravity);
+			reader.getIfPresent("bulletScale", bulletScale);
+			reader.getIfPresent("bulletColor", bulletColor);
+			reader.getIfPresent("bulletOffset", bulletOffset);
 
 			reader.getIfPresent("renderDecals", renderDecals);
 			reader.getIfPresent("missDecal", missDecal);
@@ -758,6 +764,9 @@ public:
 		if (forceAll || def.renderBullets != renderBullets)					a["renderBullets"] = renderBullets;
 		if (forceAll || def.bulletSpeed != bulletSpeed)						a["bulletSpeed"] = bulletSpeed;
 		if (forceAll || def.bulletGravity != bulletGravity)					a["bulletGravity"] = bulletGravity;
+		if (forceAll || def.bulletScale != bulletScale)						a["bulletScale"] = bulletScale;
+		if (forceAll || def.bulletColor != bulletColor)						a["bulletColor"] = bulletColor;
+		if (forceAll || def.bulletOffset != bulletOffset)					a["bulletOffset"] = bulletOffset;
 
 		if (forceAll || def.renderDecals != renderDecals)					a["renderDecals"] = renderDecals;
 		if (forceAll || def.missDecal != missDecal)							a["missDecal"] = missDecal;

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -812,6 +812,9 @@ public:
 	AABox			moveBounds;								///< Movemvent bounding box
 	Array<bool>		axisLock = { false, false, false };		///< Array of axis lock values
 
+	String			destroyDecal = "explosion_01.png";		///< Decal to use for destroy event
+	float			destroyDecalScale = 1.0;				///< Scale to apply to destroy (relative to target size)
+
 	String			hitSound = "sound/18397__inferno__smalllas.wav";	///< Sound to play when target is hit (but not destoyed)
 	float			hitSoundVol = 1.0f;						///< Hit sound volume
 	String          destroyedSound = "sound/32882__Alcove_Audio__BobKessler_Metal_Bangs-1.wav";		///< Sound to play when target destroyed
@@ -855,6 +858,10 @@ public:
 			reader.getIfPresent("jumpPeriod", jumpPeriod);
 			reader.getIfPresent("accelGravity", accelGravity);
 			reader.getIfPresent("modelSpec", modelSpec);
+
+			reader.getIfPresent("destroyDecal", destroyDecal);
+			reader.getIfPresent("destroyDecalScale", destroyDecalScale);
+			
 			reader.getIfPresent("destSpace", destSpace);
 			reader.getIfPresent("destinations", destinations);
 			reader.getIfPresent("respawnCount", respawnCount);
@@ -919,10 +926,14 @@ public:
 			if(forceAll || def.accelGravity != accelGravity)					a["accelGravity"] = accelGravity;
 			if(forceAll || def.axisLock != axisLock)							a["axisLocked"] = axisLock;
 		}
+
+		if(forceAll || def.destroyDecal != destroyDecal)						a["destroyDecal"] = destroyDecal;
+		if(forceAll || def.destroyDecalScale != destroyDecalScale)				a["destroyDecalScale"] = destroyDecalScale;
+
 		if(forceAll || def.hitSound != hitSound)								a["hitSound"] = hitSound;
 		if(forceAll || def.hitSoundVol != hitSoundVol)							a["hitSoundVol"] = hitSoundVol;
-		if(forceAll || def.destroyedSound != destroyedSound)					a["explosionSound"] = destroyedSound;
-		if(forceAll || def.destroyedSoundVol != destroyedSoundVol)				a["explosionSoundVol"] = destroyedSoundVol;
+		if(forceAll || def.destroyedSound != destroyedSound)					a["destroyedSound"] = destroyedSound;
+		if(forceAll || def.destroyedSoundVol != destroyedSoundVol)				a["destroyedSoundVol"] = destroyedSoundVol;
 		return a;
 	};
 

--- a/source/GuiElements.cpp
+++ b/source/GuiElements.cpp
@@ -318,22 +318,22 @@ WeaponControls::WeaponControls(WeaponConfig& config, const shared_ptr<GuiTheme>&
 		n->setWidth(300.0f);
 		n->setUnitsSize(50.0f);
 	} pane->endRow();
-	pane->beginRow(); {
-		auto c = pane->addLabel("Muzzle offset");
-		c->setWidth(100.0f);
-		auto n = pane->addNumberBox("X", &(config.muzzleOffset.x), "m", GuiTheme::LINEAR_SLIDER, -1.0f, 1.0f, 0.01f);
-		n->setCaptionWidth(10.0f);
-		n->setWidth(150.0f);
-		n = pane->addNumberBox("Y", &(config.muzzleOffset.y), "m", GuiTheme::LINEAR_SLIDER, -1.0f, 1.0f, 0.01f);
-		n->setCaptionWidth(10.0f);
-		n->setWidth(150.0f);
-		n = pane->addNumberBox("Z", &(config.muzzleOffset.z), "m", GuiTheme::LINEAR_SLIDER, -1.0f, 1.0f, 0.01f);
-		n->setCaptionWidth(10.0f);
-		n->setWidth(150.0f);
-	} pane->endRow();
-	pane->beginRow(); {
-		pane->addCheckBox("Muzzle flash", &(config.renderMuzzleFlash));
-	} pane->endRow();
+	//pane->beginRow(); {
+	//	auto c = pane->addLabel("Muzzle offset");
+	//	c->setWidth(100.0f);
+	//	auto n = pane->addNumberBox("X", &(config.muzzleOffset.x), "m", GuiTheme::LINEAR_SLIDER, -1.0f, 1.0f, 0.01f);
+	//	n->setCaptionWidth(10.0f);
+	//	n->setWidth(150.0f);
+	//	n = pane->addNumberBox("Y", &(config.muzzleOffset.y), "m", GuiTheme::LINEAR_SLIDER, -1.0f, 1.0f, 0.01f);
+	//	n->setCaptionWidth(10.0f);
+	//	n->setWidth(150.0f);
+	//	n = pane->addNumberBox("Z", &(config.muzzleOffset.z), "m", GuiTheme::LINEAR_SLIDER, -1.0f, 1.0f, 0.01f);
+	//	n->setCaptionWidth(10.0f);
+	//	n->setWidth(150.0f);
+	//} pane->endRow();
+	//pane->beginRow(); {
+	//	pane->addCheckBox("Muzzle flash", &(config.renderMuzzleFlash));
+	//} pane->endRow();
 
 	pack();
 	moveTo(Vector2(0, 720));

--- a/source/TargetEntity.cpp
+++ b/source/TargetEntity.cpp
@@ -54,6 +54,7 @@ shared_ptr<TargetEntity> TargetEntity::create(
 	target->Entity::init(name, scene, CFrame(config->destinations[0].position), shared_ptr<Entity::Track>(), true, true);
 	target->VisibleEntity::init(model, true, Surface::ExpressiveLightScatteringProperties(), ArticulatedModel::PoseSpline());
 	target->TargetEntity::init(config->destinations, paramIdx, offset, config->respawnCount, scaleIdx, config->logTargetTrajectory);
+	target->m_id = config->id;
 	return target;
 }
 
@@ -131,13 +132,13 @@ void TargetEntity::onSimulation(SimTime absoluteTime, SimTime deltaTime) {
 #endif
 }
 
-shared_ptr<Entity> FlyingEntity::create
-(const String&                  name,
+shared_ptr<Entity> FlyingEntity::create(
+	const String&                  name,
 	Scene*                         scene,
 	AnyTableReader&                propertyTable,
 	const ModelTable&              modelTable,
-	const Scene::LoadOptions&      loadOptions) {
-
+	const Scene::LoadOptions&      loadOptions) 
+{
 	// Don't initialize in the constructor, where it is unsafe to throw Any parse exceptions
 	const shared_ptr<FlyingEntity>& flyingEntity = createShared<FlyingEntity>();
 
@@ -172,10 +173,10 @@ shared_ptr<FlyingEntity> FlyingEntity::create(
 
 shared_ptr<FlyingEntity> FlyingEntity::create(
 	shared_ptr<TargetConfig>		config,
-	const String& name,
-	Scene* scene,
-	const shared_ptr<Model>& model,
-	const Point3& orbitCenter,
+	const String&					name,
+	Scene*							scene,
+	const shared_ptr<Model>&		model,
+	const Point3&					orbitCenter,
 	int								scaleIdx,
 	int								paramIdx)
 {
@@ -195,6 +196,7 @@ shared_ptr<FlyingEntity> FlyingEntity::create(
 		config->respawnCount, 
 		scaleIdx, 
 		config->logTargetTrajectory);
+	flyingEntity->m_id = config->id;
 	return flyingEntity;
 }
 
@@ -458,6 +460,7 @@ shared_ptr<JumpingEntity> JumpingEntity::create(
 		config->respawnCount,
 		scaleIdx,
 		config->logTargetTrajectory);
+	jumpingEntity->m_id = config->id;
 
 	return jumpingEntity;
 }

--- a/source/TargetEntity.h
+++ b/source/TargetEntity.h
@@ -56,6 +56,7 @@ public:
 
 class TargetEntity : public VisibleEntity {
 protected:
+	String	m_id;									///< Target ID
 	float	m_health			= 1.0f;				///< Target health
 	Color3	m_color				= Color3::red();	///< Default color
 	int		destinationIdx		= 0;				///< Current index into the destination array
@@ -99,8 +100,7 @@ public:
 		int								paramIdx
 	);
 
-	void init(Array<Destination> dests, int paramIdx, Point3 staticOffset = Point3(0.0, 0.0, 0.0), int respawnCount=0, int scaleIdx=0, bool isLogged=true) {
-		setDestinations(dests);
+	void init(Array<Destination> dests, int paramIdx, Point3 staticOffset = Point3(0.0, 0.0, 0.0), int respawnCount = 0, int scaleIdx = 0, bool isLogged = true) {
 		m_offset = staticOffset;
 		m_respawnCount = respawnCount;
 		m_paramIdx = paramIdx;
@@ -154,6 +154,10 @@ public:
 
 	float size() {
 		return pow(1.0f + TARGET_MODEL_ARRAY_SCALING, m_scaleIdx - TARGET_MODEL_ARRAY_OFFSET);
+	}
+
+	String id() {
+		return m_id;
 	}
 
 	/**Simple routine to do damage */

--- a/source/TargetEntity.h
+++ b/source/TargetEntity.h
@@ -69,9 +69,9 @@ protected:
 	Point3	m_offset;								///< Offset for initial spawn
 	Array<Destination> m_destinations;				///< Array of destinations to visit
 	shared_ptr<Sound> m_hitSound;					///< Sound to play when hit
-	float m_hitSoundVol;
+	float m_hitSoundVol;							///< Volume to play hit sound at
 	shared_ptr<Sound> m_destroyedSound;				///< Sound to play when destroyed
-	float m_destroyedSoundVol;
+	float m_destroyedSoundVol;						///< Volume to play destroyed sound at
 
 	// Only used for flying/jumping entities
 	SimTime m_nextChangeTime = 0;
@@ -122,7 +122,7 @@ public:
 
 	void setWorldSpace(bool worldSpace) { m_worldSpace = worldSpace; }
 
-	void setHitSound(String hitSoundFilename, float hitSoundVol = 1.0f) {
+	void setHitSound(const String& hitSoundFilename, float hitSoundVol = 1.0f) {
 		if (hitSoundFilename == "") { m_hitSound = nullptr; }
 		else { 
 			m_hitSound = Sound::create(System::findDataFile(hitSoundFilename)); 
@@ -130,7 +130,7 @@ public:
 		}
 	}
 
-	void setDestoyedSound(String destroyedSoundFilename, float destroyedSoundVol = 1.0f){
+	void setDestoyedSound(const String& destroyedSoundFilename, float destroyedSoundVol = 1.0f){
 		if (destroyedSoundFilename == "") { m_destroyedSound = nullptr;  }
 		else {
 			m_destroyedSound = Sound::create(System::findDataFile(destroyedSoundFilename));
@@ -150,14 +150,6 @@ public:
 			if (volume > 0.0f) { m_destroyedSound->play(volume);  }
 			else { m_destroyedSound->play(m_destroyedSoundVol); }
 		}
-	}
-
-	float size() {
-		return pow(1.0f + TARGET_MODEL_ARRAY_SCALING, m_scaleIdx - TARGET_MODEL_ARRAY_OFFSET);
-	}
-
-	String id() {
-		return m_id;
 	}
 
 	/**Simple routine to do damage */
@@ -181,22 +173,25 @@ public:
 	void resetMotionParams() {
 		m_nextChangeTime = 0;
 	}
-
-	int scaleIndex() {
-		return m_scaleIdx;
-	}
-
-	bool isLogged() {
-		return m_isLogged;
-	}
-
+	
+	/** Get the target ID */
+	const String& id() const { return m_id; }
+	/** Getter for scale index */
+	int scaleIndex() const { return m_scaleIdx; }
+	/** Getter for logging */
+	bool isLogged() const { return m_isLogged; }
 	/** Getter for health */
-	float health() { return m_health; }
-	/**Get the total time for a path*/
-	float getPathTime() { return m_destinations.last().time; }
-	Array<Destination> destinations() { return m_destinations; }
-	int respawnsRemaining() { return m_respawnCount; }
-	int paramIdx() { return m_paramIdx; }
+	float health() const { return m_health; }
+	/** Getter for the total time for a path*/
+	float getPathTime() const { return m_destinations.last().time; }
+	/** Get the target size */
+	float size() const { return pow(1.0f + TARGET_MODEL_ARRAY_SCALING, m_scaleIdx - TARGET_MODEL_ARRAY_OFFSET); }
+	/** Getter for the target destinations */
+	Array<Destination> destinations() const { return m_destinations; }
+	/** Getter for remaining respawn count */
+	int respawnsRemaining() const { return m_respawnCount; }
+	/** Getter for parmaeter index */
+	int paramIdx() const { return m_paramIdx; }
 
 	void drawHealthBar(RenderDevice* rd, const Camera& camera, const Framebuffer& framebuffer, Point2 size, Point3 offset, Point2 border, Array<Color4> colors, Color4 borderColor) const;
 	virtual void onSimulation(SimTime absoluteTime, SimTime deltaTime) override;

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -2,7 +2,7 @@
 
 
 void Weapon::onPose(Array<shared_ptr<Surface> >& surface) {
-	if (m_config->renderModel || m_config->renderBullets || m_config->renderMuzzleFlash) {
+	if (m_config->renderModel || m_config->renderBullets) { // || m_config->renderMuzzleFlash) {
 		// Update the weapon frame for all of these cases
 		const float yScale = -0.12f;
 		const float zScale = -yScale * 0.5f;

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -38,6 +38,9 @@ shared_ptr<TargetEntity> Weapon::fire(
 	if (m_config->renderBullets || !m_config->hitScan) {
 		// Create the bullet start frame from the weapon frame plus muzzle offset
 		CFrame bulletStartFrame = m_camera->frame();
+		
+		// Apply bullet offset w/ camera rotation here
+		bulletStartFrame.translation += m_camera->frame().rotation * m_config->bulletOffset;
 
 		// Angle the bullet start frame towards the aim point
 		Point3 aimPoint = m_camera->frame().translation + m_camera->frame().lookVector() * 1000.0f;

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -93,17 +93,21 @@ public:
 		}
 
 		// Create the bullet model
-		const static Any bulletSpec = PARSE_ANY(ArticulatedModel::Specification{
-			filename = "ifs/d10.ifs";
-			preprocess = {
-				transformGeometry(all(), Matrix4::pitchDegrees(90));
-				transformGeometry(all(), Matrix4::scale(0.05,0.05,2));
-				setMaterial(all(), UniversalMaterial::Specification {
-					lambertian = Color3(0);
-					emissive = Power3(5,4,0);
-				});
-			}; 
-		});
+		const Vector3& scale = m_config->bulletScale;
+		const Color3& color = m_config->bulletColor;
+		const static Any bulletSpec = Any::parse(format(
+			"ArticulatedModel::Specification{\
+				filename = \"ifs/d10.ifs\";\
+				preprocess = {\
+					transformGeometry(all(), Matrix4::pitchDegrees(90));\
+					transformGeometry(all(), Matrix4::scale(%f,%f,%f));\
+					setMaterial(all(), UniversalMaterial::Specification {\
+						lambertian = Color3(0);\
+						emissive = Power3(%f,%f,%f);\
+					});\
+				};\
+			}", 
+			scale.x, scale.y, scale.z, color.r, color.g, color.b));
 		m_bulletModel = ArticulatedModel::create(bulletSpec, "bulletModel");
 	}
 


### PR DESCRIPTION
This branch includes development of additional controls for rendered "bullets" and explosions (aka target destroy decals). This comes from a request from @joohwankimNV suggesting issues that are arising from new use cases.

Things to Do Include
---
* Bullets
  * Size control
  * Start point/offset control
  * _Color control_
* Explosions
  * Tie explosion time to simulation time (`sdt` approach)
  * Allow user customization of "destroy decal" (size/texture/display time) _on a per-target basis_
