### PR TITLE
Don't allow the same Target ID to be entered multiple times

### DIFF
--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1642,6 +1642,18 @@ public:
 			
 			targets.append(tJump);
 		}
+		else {
+			// Targets are present (make sure no 2 have the same ID)
+			Array<String> ids;
+			for (TargetConfig target : targets) { 
+				if (!ids.contains(target.id)) { ids.append(target.id); }
+				else {
+					// This is a repeat entry, throw an exception
+					throw format("Found duplicate target configuration for target: \"%s\"", target.id);
+				}
+			}
+			
+		}
 
 		if(sessions.size() == 0 && addedTargets){
 			SessionConfig sess60;


### PR DESCRIPTION
Currently an experiment designer can specify two different targets with the same `id` field value in the `experimentconfig.Any` file.

This was described in Issue #109. This branch fixes this problem by raising an exception at `experimentconfig.Any` load time if any two specified targets share a common `id`.