### PR TITLE
Split SystemConfig into Input/Config Files and HW Information/Output Files

### DIFF
--- a/source/App.cpp
+++ b/source/App.cpp
@@ -42,10 +42,13 @@ void App::onInit() {
 	userStatusTable.printToLog();
 	userStatusTable.validate(sessionIds);
 	
+	// Get info about the system
+	SystemInfo info = SystemInfo::get();
+	info.printToLog();										// Print system info to log.txt
+
 	// Get and save system configuration
 	systemConfig = SystemConfig::load();
-	systemConfig.printToLog();											// Print system info to log.txt
-	systemConfig.toAny().save("systemconfig.Any");						// Update the any file here (new system info to write)
+	systemConfig.printToLog();								// Print the system config to log.txt								
 
 	displayRes = OSWindow::primaryDisplaySize();						
 

--- a/source/App.cpp
+++ b/source/App.cpp
@@ -47,9 +47,10 @@ void App::onInit() {
 	info.printToLog();										// Print system info to log.txt
 
 	// Get and save system configuration
-	systemConfig = SystemConfig::load();
-	systemConfig.printToLog();								// Print the system config to log.txt								
+	latencyLoggerConfig = LatencyLoggerConfig::load();
+	latencyLoggerConfig.printToLog();						// Print the latency logger config to log.txt								
 
+	// Get the size of the primary display
 	displayRes = OSWindow::primaryDisplaySize();						
 
 	// Load the key binds
@@ -516,12 +517,12 @@ void App::updateSession(const String& id) {
 
 	// Check for need to start latency logging and if so run the logger now
 	String logName = "../results/" + id + "_" + userTable.currentUser + "_" + String(FPSciLogger::genFileTimestamp());
-	if (systemConfig.hasLogger) {
+	if (latencyLoggerConfig.hasLogger) {
 		if (!sessConfig->clickToPhoton.enabled) {
 			logPrintf("WARNING: Using a click-to-photon logger without the click-to-photon region enabled!\n\n");
 		}
 		if (m_pyLogger == nullptr) {
-			m_pyLogger = PythonLogger::create(systemConfig.loggerComPort, systemConfig.hasSync, systemConfig.syncComPort);
+			m_pyLogger = PythonLogger::create(latencyLoggerConfig.loggerComPort, latencyLoggerConfig.hasSync, latencyLoggerConfig.syncComPort);
 		}
 		else {
 			// Handle running logger if we need to (terminate then merge results)

--- a/source/App.h
+++ b/source/App.h
@@ -119,7 +119,7 @@ public:
 	UserTable						userTable;						///< Table of per user information (DPI/cm/360) that doesn't change across experiment
 	UserStatusTable					userStatusTable;				///< Table of user status (session ordering/completed sessions) that do change across experiments
 	ExperimentConfig                experimentConfig;				///< Configuration for the experiment and its sessions
-	SystemConfig					systemConfig;					///< Configuration for the system/hardware
+	LatencyLoggerConfig				latencyLoggerConfig;			///< Configuration for the system/hardware
 	KeyMapping						keyMap;
 	shared_ptr<WaypointManager>		waypointManager;				///< Waypoint mananger pointer
 	

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -250,7 +250,7 @@ public:
 
 	void printToLog() {
 		// Print system info to log
-		logPrintf("\n-------------------\nSystem Info:\n-------------------\n\tHostname: %s\n\tUsername: %s\n\tProcessor: %s\n\tCore Count: %d\n\tMemory: %dMB\n\tGPU: %s\n\tDisplay: %s\n\tDisplay Resolution: %d x %d (px)\n\tDisplay Size: %d x %d (mm)\n",
+		logPrintf("\n-------------------\nSystem Info:\n-------------------\n\tHostname: %s\n\tUsername: %s\n\tProcessor: %s\n\tCore Count: %d\n\tMemory: %dMB\n\tGPU: %s\n\tDisplay: %s\n\tDisplay Resolution: %d x %d (px)\n\tDisplay Size: %d x %d (mm)\n\n",
 			hostName, userName, cpuName, coreCount, memCapacityMB, gpuName, displayName, displayXRes, displayYRes, displayXSize, displayYSize);
 	}
 };
@@ -304,14 +304,15 @@ public:
 		return Any::fromFile(System::findDataFile("systemconfig.Any"));
 	}
 
-
 	/** Print the latency logger config to log.txt */
 	void printToLog() {
-		logPrintf("\n-------------------\LDAT-R Config:\n-------------------\n\tLogger Present: %s\n\tLogger COM Port: %s\n\tSync Card Present: %s\n\tSync COM Port: %s\n",
-			hasLogger ? "True" : "False", 
-			hasLogger ? loggerComPort : "None", 
-			hasSync ? "True" : "False", 
-			hasSync ? syncComPort : "None"
+		const String loggerComStr = hasLogger ? loggerComPort : "None";
+		const String syncComStr = hasSync ? syncComPort : "None";
+		logPrintf("-------------------\nLDAT-R Config:\n-------------------\n\tLogger Present: %s\n\tLogger COM Port: %s\n\tSync Card Present: %s\n\tSync COM Port: %s\n\n",
+			hasLogger ? "True" : "False",
+			loggerComStr.c_str(),
+			hasSync ? "True" : "False",
+			syncComStr.c_str()
 		);
 	}
 };

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -145,6 +145,8 @@ The current implementation is heavily Windows - specific */
 class SystemInfo {
 public: 
 	// Output/runtime read parameters
+	String	hostName;			///< System host (PC) name
+	String  userName;			///< System username
 	String	cpuName;			///< The vendor name of the CPU being used
 	int		coreCount;			///< Core count for the CPU being used
 	String	gpuName;			///< The vendor name of the GPU being used
@@ -158,6 +160,10 @@ public:
 	/** Get the system info using (windows) calls */
 	static SystemInfo get(void) {
 		SystemInfo info;
+
+		info.hostName = getenv("COMPUTERNAME");		// Get the host (computer) name
+		info.userName = getenv("USERNAME");			// Get the current logged in username
+
 		// Get CPU name string
 		int cpuInfo[4] = { -1 };
 		unsigned nExIds, i = 0;
@@ -228,6 +234,8 @@ public:
 
 	Any toAny(const bool forceAll = true) const {
 		Any a(Any::TABLE);
+		a["hostname"] = hostName;
+		a["username"] = userName;
 		a["CPU"] = cpuName;
 		a["GPU"] = gpuName;
 		a["CoreCount"] = coreCount;
@@ -242,8 +250,8 @@ public:
 
 	void printToLog() {
 		// Print system info to log
-		logPrintf("\n-------------------\nSystem Info:\n-------------------\n\tProcessor: %s\n\tCore Count: %d\n\tMemory: %dMB\n\tGPU: %s\n\tDisplay: %s\n\tDisplay Resolution: %d x %d (px)\n\tDisplay Size: %d x %d (mm)\n",
-			cpuName, coreCount, memCapacityMB, gpuName, displayName, displayXRes, displayYRes, displayXSize, displayYSize);
+		logPrintf("\n-------------------\nSystem Info:\n-------------------\n\tHostname: %s\n\tUsername: %s\n\tProcessor: %s\n\tCore Count: %d\n\tMemory: %dMB\n\tGPU: %s\n\tDisplay: %s\n\tDisplay Resolution: %d x %d (px)\n\tDisplay Size: %d x %d (mm)\n",
+			hostName, userName, cpuName, coreCount, memCapacityMB, gpuName, displayName, displayXRes, displayYRes, displayXSize, displayYSize);
 	}
 };
 

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -247,19 +247,19 @@ public:
 	}
 };
 
-/** System hardware setup/logging configuration */
-class SystemConfig {
+/** Latency logging configuration */
+class LatencyLoggerConfig {
 public:
 	// Input parameters
-	bool	hasLogger = false;			///< Indicates that a hardware logger is present in the system
+	bool	hasLogger = false;		///< Indicates that a hardware logger is present in the system
 	String	loggerComPort = "";		///< Indicates the COM port that the logger is on when hasLogger = True
-	bool	hasSync = false;			///< Indicates that a hardware sync will occur via serial card DTR signal
+	bool	hasSync = false;		///< Indicates that a hardware sync will occur via serial card DTR signal
 	String	syncComPort = "";		///< Indicates the COM port that the sync is on when hasSync = True
 
-	SystemConfig() {};
+	LatencyLoggerConfig() {};
 
 	/** Construct from Any */
-	SystemConfig(const Any& any) {
+	LatencyLoggerConfig(const Any& any) {
 		int settingsVersion = 1;
 		AnyTableReader reader(any);
 		reader.getIfPresent("settingsVersion", settingsVersion);
@@ -287,19 +287,19 @@ public:
 		return a;
 	}
 
-	/** Load a system config from file */
-	static SystemConfig load() {
-		// if file not found, create a default system config
+	/** Load a latency logger config from file */
+	static LatencyLoggerConfig load() {
+		// if file not found, create a default latency logger config
 		if (!FileSystem::exists("systemconfig.Any")) { 
-			return SystemConfig();		// Create the default
+			return LatencyLoggerConfig();		// Create the default
 		}
 		return Any::fromFile(System::findDataFile("systemconfig.Any"));
 	}
 
 
-	/** Print the system info to log.txt */
+	/** Print the latency logger config to log.txt */
 	void printToLog() {
-		logPrintf("\n-------------------\nSystem Config:\n-------------------\n\tLogger Present: %s\n\tLogger COM Port: %s\n\tSync Card Present: %s\n\tSync COM Port: %s\n",
+		logPrintf("\n-------------------\LDAT-R Config:\n-------------------\n\tLogger Present: %s\n\tLogger COM Port: %s\n\tSync Card Present: %s\n\tSync COM Port: %s\n",
 			hasLogger ? "True" : "False", 
 			hasLogger ? loggerComPort : "None", 
 			hasSync ? "True" : "False", 

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -141,7 +141,7 @@ public:
 };
 
 /** Information about the system being used
-The current implementation is heavily Windows - specific */
+The current implementation is heavily Windows-specific */
 class SystemInfo {
 public: 
 	// Output/runtime read parameters


### PR DESCRIPTION
This branch splits the `SystemConfig` structure, previously used as an `inout` file into it's 2 constituent parts:

* System hardware configuration input (i.e. configuration for the LDAT-R logger interface)
* System hardware description output (CPU, GPU, RAM, Display Info)

Currently the system hardware info is (only) written to `log.txt` and duplicates some of the native information provided by G3D (see more about this in issue #128). We could instead/also:

* Write the system info to the output database
* Create a new output text/CSV file that only contains our (formatted) system info
* Use this information for automatic validation that the system meets some (specificed) min spec for certain experiments

Currently the `SystemInfo` class has been implemented (in `configFiles.h`) to get/store system hardware information separately from logger configuration parameters (using the existing `SystemConfig` class).

Merging this request closes #128.