### PR TITLE
Documentation fixes

### DIFF
--- a/docs/experimentConfigReadme.md
+++ b/docs/experimentConfigReadme.md
@@ -11,7 +11,7 @@ Broad areas of control included in this config file include:
 For a full description of fields see the descriptions below. Along with each subsection an example configuration is provided. In many cases the example values below are the defaults provided in these field values. Where this is not the case the default will be indicated in the comments.
 
 ## File Location
-The [`experimentconfig.Any` file](../data-files/experimentconfig.Any) is located in the [`data-files`](../data-files/) directory at the root of the project. If no `experimentconfig.Any` file is present at startup, [`SAMPLEexperimentconfig.Any`](../data-files/SAMPLEexperimentconfig.Any) is copied to `experimentconfig.Any`.
+The `experimentconfig.Any` file is located in the [`data-files`](../data-files/) directory at the root of the project. If no `experimentconfig.Any` file is present at startup, a default experiment configuration is written to `experimentconfig.Any`.
 
 # Experiment Config Field Descriptions
 
@@ -155,7 +155,7 @@ targets = [
 ```
 
 ## Target Paths (Using Destinations)
-The `destinations` array within the target object overrides much of the default motion behavior in the target motion controls. Once a destinations array (including more than 2 destiantions) is specified all other motion parameters are considered unused. Once a `destinations` array is specified only the following fields from the [target configuration](###-Target-Configuration) apply:
+The `destinations` array within the target object overrides much of the default motion behavior in the target motion controls. Once a destinations array (including more than 2 destiantions) is specified all other motion parameters are considered unused. Once a `destinations` array is specified only the following fields from the [target configuration](#target-configuration) apply:
 
 * `id`
 * `visualSize`

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -240,6 +240,36 @@ Each question in the array is then asked of the user (via an independent time-se
 "cooldownColor": Color4(1.0,1.0,1.0,0.75),  // White w/ 75% alpha
 ```
 
+### Static HUD Elements
+In addition to the (dynamic) HUD elements listed above, arbitrary lists of static HUD elements can be provided to draw in the UI using the `staticHUDElements` parameter in a general config. The `staticHUDElements` parameter value is an array of elements, each of which specifies the following sub-parameters:
+
+| Parameter Name    | Type      | Description                                                                               |
+|-------------------|-----------|-------------------------------------------------------------------------------------------|
+|`filename`         |`String`   | A filename to find for the image to draw (`.png` files are suggested)                     |
+|`position`         |`Vector2`  | The position to draw the element centered at, as a ratio of screen space (i.e. `Vector2(0.5, 0.5) for an element in the middle of the screen)  |
+|`scale`            |`Vector2`  | An additional scale to apply to the drawn element (as a fraction of it's original size)   | 
+
+The `position` parameter specifies the offset to the center of the image with `Vector2(0,0)` indicating the top-left corner and `Vector2(1,1)` indicating the bottom-right corner of the window).
+
+No static HUD elements are drawn by default. An example snippet including 2 (non-existant) HUD elements is provided below for reference:
+
+```
+"staticHUDElements" : [
+    // Element 1 (centered and scaled)
+    {
+        "filename": "centerImage.png",              // Use this file to draw an image (should be within data-files directory)
+        "position": Vector2(0.5, 0.5),              // Center the image (draw it's center at 1/2 the screen size horizontal/vertical)
+        "scale": Vector2(0.25, 0.25)                // Scale the image by 1/4 it's original resolution
+    },
+    // Element 2 (unscaled)
+    {
+        "filename" : "hud/unscaled.png",            // Use this filename (can add relative paths to directories that won't be searched implicitly)
+        "position": Vector2(0,0)                    // Draw this element at the top-left of the screen
+        // No scale specification implies Vector2(1,1) scaling
+    }
+]
+```
+
 ## Click to Photon Monitoring
 These flags help control the behavior of click-to-photon monitoring in application:
 
@@ -328,35 +358,6 @@ These flags help control the behavior of click-to-photon monitoring in applicati
 "floatingCombatTextTimeout": 0.5,                           // Fade out the combat text in 0.5s
 ```
 
-### Static HUD Elements
-In addition to the (dynamic) HUD elements listed above, arbitrary lists of static HUD elements can be provided to draw in the UI using the `staticHUDElements` parameter in a general config. The `staticHUDElements` parameter value is an array of elements, each of which specifies the following sub-parameters:
-
-| Parameter Name    | Type      | Description                                                                               |
-|-------------------|-----------|-------------------------------------------------------------------------------------------|
-|`filename`         |`String`   | A filename to find for the image to draw (`.png` files are suggested)                     |
-|`position`         |`Vector2`  | The position to draw the element centered at, as a ratio of screen space (i.e. `Vector2(0.5, 0.5) for an element in the middle of the screen)  |
-|`scale`            |`Vector2`  | An additional scale to apply to the drawn element (as a fraction of it's original size)   | 
-
-The `position` parameter specifies the offset to the center of the image with `Vector2(0,0)` indicating the top-left corner and `Vector2(1,1)` indicating the bottom-right corner of the window).
-
-No static HUD elements are drawn by default. An example snippet including 2 (non-existant) HUD elements is provided below for reference:
-
-```
-"staticHUDElements" : [
-    // Element 1 (centered and scaled)
-    {
-        "filename": "centerImage.png",              // Use this file to draw an image (should be within data-files directory)
-        "position": Vector2(0.5, 0.5),              // Center the image (draw it's center at 1/2 the screen size horizontal/vertical)
-        "scale": Vector2(0.25, 0.25)                // Scale the image by 1/4 it's original resolution
-    },
-    // Element 2 (unscaled)
-    {
-        "filename" : "hud/unscaled.png",            // Use this filename (can add relative paths to directories that won't be searched implicitly)
-        "position": Vector2(0,0)                    // Draw this element at the top-left of the screen
-        // No scale specification implies Vector2(1,1) scaling
-    }
-]
-```
 
 ## Menu Config
 These flags control the display of the in-game user menu:

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -28,7 +28,7 @@ If a scene name is specified at the experiment level it will be applied to all s
 ```
 
 ## Weapon Configuration
-* `weapon` provides a configuration for the weapon used in the experiment (for more info see [the weapon config readme](../data-files/weapon/weaponConfigReadme.md))
+* `weapon` provides a configuration for the weapon used in the experiment (for more info see [the weapon config readme](weaponConfigReadme.md))
 
 The `weapon` config should be thought of as an atomic type (just like an `int` or `float`). Even though it is a (more complex) data structure, it does not use the experiment-->session level inheritance appraoch offered elsewhere in the configuration format (i.e. any `weapon` specification should be complete). For this reason we recommend storing weapon configurations in independent `.weapon.Any` files and including them using the `.Any` `#include()` directive.
 

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -52,7 +52,7 @@ The following settings allow the user to control various timings/durations aroun
 |---------------------------|-------|--------------------------------------------------------------------|
 |`horizontalFieldOfView`    |°      |The (horizontal) field of view for the user's display, to get the vertical FoV multiply this by `1 / your display's aspect ratio` (9/16 for common FHD, or 1920x1080)|
 |`frameDelay`               |frames | An (integer) count of frames to delay to control latency           |
-|`frameRate`                |fps/Hz | The (target) frame rate of the display (constant for a given session) for more info see the [Frame Rate Modes section](#Frame-Rate-Modes) below.|
+|`frameRate`                |fps/Hz | The (target) frame rate of the display (constant for a given session) for more info see the [Frame Rate Modes section](#frame-rate-modes) below.|
 |`shader`                   |file    | The (relative) path/filename of an (optional) shader to run (as a `.pix`) |
 
 ```
@@ -394,6 +394,7 @@ These flags control the display of the in-game user menu:
 "allowReticleColorChange": true,        // If reticle changes are enabled, allow color changes
 "allowReticleTimeChange": false,        // Even if reticle change is enabled, don't allow "shrink time" to change
 "showReticlePreview": true              // If reticle changes are enabled show the preview
+```
 
 ## Logger Config
 These flags control whether various information is written to the output database file:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -32,7 +32,7 @@ When authoring an initial experiment config we can rely on many of the deafult v
 #### Setting Up a Target
 There are a few fields we will need to populate manually to provide an interesting experiment. One of the first non-generic things to specify in an experiment config is the `targets` array. This array provides (named) targets that can be used to setup trials within sessions later in the configuration.
 
-To start with we will setup a simple target that uses the apps default target model and avoids world-space coordinates since these would be specific to a particular scene. For more information on setting up targets refer to [the `experimenyconfig.Any` readme](experimentConfigReadme.md).
+To start with we will setup a simple target that uses the apps default target model and avoids world-space coordinates since these would be specific to a particular scene. For more information on setting up targets refer to [the `experimenyconfig.Any` readme](experimentConfigReadme.md#target-configuration).
 
 ```
     targets = [
@@ -94,7 +94,7 @@ Let's create a single user for our new experiment. To do this we will start in t
 In the file above we create a new user (user name is "user") and set them as the `currentUser` for the application. Note that the user id set as the `currentUser` should always appear in the `users` array within the `userconfig.Any` file.
 
 #### User Status
-Now that we have a configuration for our new user, we can update the [`userstatus.Any` file](userStatusReadme.md) to link our new session (created [above](####-Adding-Sessions)) to this user. This is done as shown below:
+Now that we have a configuration for our new user, we can update the [`userstatus.Any` file](userStatusReadme.md) to link our new session (created [above](#adding-sessions)) to this user. This is done as shown below:
 
 ```
 {

--- a/docs/startupConfigReadme.md
+++ b/docs/startupConfigReadme.md
@@ -2,7 +2,7 @@
 The startup config is the highest level configuration file provided to `FirstPersonScience`. This file specifies the experiment configuration path, as well as the user configuration path and play mode.
 
 ## File Location
-The [`startupconfig.Any` file](../data-files/startupconfig.Any) is located in the [`data-files` directory](../data-files/) in the root of the project. If no `startupconfig.Any` is present at launch the application will create one.
+The `startupconfig.Any` file is located in the [`data-files` directory](../data-files/) in the root of the project. If no `startupconfig.Any` is present at launch the application will create one.
 
 # Fields
 The following fields are valid for a startupconfig.Any file:

--- a/docs/systemConfigReadme.md
+++ b/docs/systemConfigReadme.md
@@ -1,8 +1,8 @@
 # System Configuration
-The system configuration file plays a dual role in `FirstPersonScience`. First it provides configuration information related to the hardware setup of the machine (namely whether a hardware click-to-photon logger is present and if so which COM port it uses). Second it records the system parameters from the experiment for later analysis.
+The system configuration file provides configuration information related to the hardware setup of the machine (namely whether a hardware click-to-photon logger and it's affiliated serial sync card is present and if so which COM port each uses).
 
 ## File Location
-The [`systemconfig.Any` file](../data-files/systemconfig.Any) is located in the [`data-files` directory](../data-files/) at the top of the project. If no `systemconfig.Any` file is present at startup the application copies [`SAMPLEsystemconfig.Any`](../data-files/SAMPLEsystemconfig.Any) to `systemconfig.Any`.
+The `systemconfig.Any` file is located in the [`data-files` directory](../data-files/) at the top of the project. If no `systemconfig.Any` file is present at startup the application writes a default config (which assumes no hardware latency logger is present) to `systemconfig.Any`.
 
 # Input Fields
 The following fields are input to the `systemconfig.Any` file:
@@ -12,10 +12,10 @@ The following fields are input to the `systemconfig.Any` file:
 * `HasSync` indicates whether the system has an additional serial card where the DTR signal will be used for timebase syncing the logger to the PC (if `HasLogger` is `true` and `HasSync` is false, the first USB packet exchanged through the system is used to create the timestamp at a lower precision).
 * `SyncComPort` indicates the port on which the sync card is connected if `HasSync` is set to `true`. Generally speaking these ports tend to be enumerated at lower port numbers (i.e. `COM0` or `COM1`) than the Virtual COM Ports (VCPs) produced by USB.
 
-Refer to the [SAMPLEsystemconifg.Any file](SAMPLEsystemconfig.Any) for an example of this.
+`LoggerComPort` and `SyncComPort` are ignored if their affiliated `HasLogger`/`HasSync` fields are not set to `true`.
 
-# Output Fields
-The following fields are written by the application as output from the `systemconfig.Any` file:
+# (Historical) Output Fields
+The following fields were (historically) written by the application as output from the `systemconfig.Any` file, but are no longer:
 
 * `CPU` is the reported name of the CPU being run on
 * `CoreCount` represents the core count of the CPU being run on
@@ -27,4 +27,4 @@ The following fields are written by the application as output from the `systemco
 * `DisplaySizeXmm` provides the horizontal size of the display (in mm)
 * `DisplaySizeYmm` provides the vertical size of the display (in mm)
 
-These parameters (as input) have no effect on the application.
+These parameters are now written to `log.txt` at startup to avoid confusion and make `startupconfig.Any` a "pure" configuration (i.e. input) file.

--- a/docs/userConfigReadme.md
+++ b/docs/userConfigReadme.md
@@ -6,7 +6,7 @@ The high-level `userconfig.Any` file provides the `currentUser` (the default use
 The user config is setup to work across multiple experiments (i.e. it does not have any information specific to an `experimentconfig.Any` file contained within in). For per user session ordering see the [`userStatus.Any`](./userStatusReadme.md).
 
 ## File Location
-The [`userconfig.Any` file](../data-files/userconfig.Any) is located in the [`data-files` directory](../data-files/) at the root of the project. If no `userconfig.Any` file is present the application copies [`SAMPLEuserconfig.Any`](../data-files/SAMPLEuserconfig.Any) to `userconfig.Any`.
+The `userconfig.Any` file is located in the [`data-files` directory](../data-files/) at the root of the project. If no `userconfig.Any` file is present the application writes a default to `userconfig.Any`. The default user is named `anon` and corresponds to the default `userstatus.Any` file. This config assumes an 800DPI mouse and a 12.75cm/360° mouse sensitivity without mouse inversion.
 
 # User Table
 Each entry in the user table contains the following fields:
@@ -24,7 +24,23 @@ Each entry in the user table contains the following fields:
 |`turnScale`          |`Vector2(float)`|Provides a per-player view rotation/mouse sensitivity scale, designed to compound with the experiment/session-level `turnScale`.|
 |`scopeTurnScale`     |`Vector2(float)`|Provides an (optional) additional turn scale to apply when scoped. If this value is `Vector2(0,0)` (or unspecified) then a "default" scaling of the ratio of FoV (scoped vs unscoped) is used to scale mouse sensitivity |
 
-Refer to the [SAMPLEuserconfig.Any file](SAMPLE%20configs/SAMPLEuserconfig.Any) for an example of these settings.
+The full specification for the default user is provided below as an example:
+
+```
+id = "anon";                // "anon" is the application-wide default user name
+mouseDPI = 800;             // 800 DPI mouse
+cmp360 = 12.75;             // 12.75 cm for full rotation
+turnScale = Vector2(1,1);   // Don't apply any additional mouse-based turn scaling
+invertY = false;            // Don't invert Y mouse controls
+scopeTurnScale = (0,0);     // Don't modify turn scale when scoped
+
+currentSession = 0;         // Select the first session by default
+
+reticleIndex = 39;          
+reticleScale = {1,1}        // Don't scale the reticle after a shot
+reticleColor = {Color4(1.0, 0.0, 0.0, 1.0), Color4(1.0, 0.0, 0.0, 1.0)};    // Use a green reticle (no color change)
+reticleChangeTimeS = 0.3;   // Doesn't matter since color/size don't chnage
+```
 
 ### Sensitivity Measure (cm/360°)
 Many games use arbitrary mouse sensitivity measures (i.e. 0-10 or low, mid, high scale) to set mouse sensitivity based on iterative player testing (i.e. choose a setting, test whether it meets your needs, adjust the setting accordingly). Unfortunately this means that mouse sensitivity settings can often not be easily translated between applications without a tool to convert between the settings values.
@@ -41,7 +57,7 @@ In order to preview reticles we suggest either:
 
 If you would not like to have a dynamic reticle (i.e. have it stay the same size/color all the time), then set both values in the array for `reticleScale` and `reticleColor` to the same value.
 
-Since an example of this is not provided in the [SAMPLEuserconfig.Any file](SAMPLE%20configs/SAMPLEuserconfig.Any) file, we will provide one below for a single-user case:
+An example of a non-default user configuration is provided below for a single-user case:
 
 ```
 users = [ 

--- a/docs/userStatusReadme.md
+++ b/docs/userStatusReadme.md
@@ -4,7 +4,7 @@ The user status file tracks all user infomration specific to a given experiment 
 The user status is the primary mechanism by which sessions are ordered and progress is tracked in `FirstPersonScience`. Similarly to the [`userconfig.Any`](./userConfigReadme.md) this file controls per-user actions using a user table and also records completed sessions so that the application can track user progress over multiple runtimes.
 
 ## File Location
-The [`userstatus.Any` file](../data-files/userconfig.Any) is located in the [`data-files` directory](../data-files) at the root of the project. If no `userstatus.Any` file is present at startup the application copies [`SAMPLEuserstatus.Any`](../data-files/SAMPLEuserstatus.Any) to `userstatus.Any`.
+The `userstatus.Any` file is located in the [`data-files` directory](../data-files) at the root of the project. If no `userstatus.Any` file is present at startup the application writes a set of default values to `userstatus.Any`. The default user name in this file is `anon` and the sessions assigned to this user refer to the default values for `experimentconfig.Any` to make the solution work as-is without any config files present.
 
 # User Table
 The top-level user status table contains the following fields:
@@ -18,8 +18,6 @@ Each entry in the user table contains the following fields:
 * `id` a quick ID used to identify the user
 * `sessions` a list of sessions to be completed, in order
 * `completedSessions` a list of sessions completed by any given user
-
-Refer to the [SAMPLEuserstatus.Any file](../data-files/SAMPLEuserstatus.Any) for an example of these settings.
 
 The `sessions` list above can be used to control session ordering (this is an ordered list). If random ordering is desired a quick script can be written to read all users from the `userconfig.Any` file and write a new sequence of sessions for each user present. Alternatively the top-level `sessions` list can be used to specify a single ordering for all participants:
 

--- a/docs/weaponConfigReadme.md
+++ b/docs/weaponConfigReadme.md
@@ -1,5 +1,5 @@
 # Introduction
-The weapon config allows for a modular configuration of the weapon used during an [experiment](experimentConfigReadme.md). Weapon configurations can either be inlined into the [`experimentconfig.Any`](../data-files/SAMPLEexperimentconfig.Any#L16) or included as independent `.Any` file using the `#include("file.Any")` directive in the experiment configuration file to refer to a `[filename].weapon.Any` file (or any other `.Any` file including a weapon). If you plan to regularly change weapons we suggest using the later approach.
+The weapon config allows for a modular configuration of the weapon used during an [experiment](experimentConfigReadme.md). Weapon configurations can either be [inlined](AnyFile.md#including-other-any-files) into the `experimentconfig.Any` or included as independent `.Any` file using the `#include("file.Any")` directive in the experiment configuration file to refer to a `[filename].weapon.Any` file (or any other `.Any` file including a weapon). If you plan to regularly change weapons we suggest using the later approach.
 
 In the future support for a weapon editor might be offered as part of the application.
 


### PR DESCRIPTION
Updating some issues found in the documentation, these include:

* Static HUD documented under the wrong section of general config
* Broken link to weapon configuration from the general config
* Removing links to no longer present config files
* Updating header/section links to get them working in Github

Only markdown/documentation files should change as part of this branch/pull request.

This branch can remain present after merging this pull request to give us a place to address future documentation problems not discovered in affiliation with a specific feature/pull request.