### PR TITLE
Fix for "Select Session" bug

### DIFF
--- a/source/App.cpp
+++ b/source/App.cpp
@@ -203,9 +203,7 @@ void App::loadModels() {
 
 void App::updateControls() {
 	// Update the user settings window
-	removeWidget(m_userSettingsWindow);
-	m_userSettingsWindow->setConfig(sessConfig->menu);
-	addWidget(m_userSettingsWindow);
+	m_updateUserMenu = true;
 
 	// Update the waypoint manager
 	waypointManager->updateControls();
@@ -558,6 +556,7 @@ void App::onSimulation(RealTime rdt, SimTime sdt, SimTime idt) {
 	m_widgetManager->onSimulation(rdt, sdt, idt);
 	if (scene()) { scene()->onSimulation(sdt); }
 
+
 	// make sure mouse sensitivity is set right
 	if (m_userSettingsWindow->visible()) {
 		updateMouseSensitivity();
@@ -748,6 +747,26 @@ bool App::onEvent(const GEvent& event) {
 
 	// Handle super-class events
 	return GApp::onEvent(event);
+}
+
+void App::onAfterEvents() {
+	if (m_updateUserMenu) {
+		// Remove the old settings window
+		removeWidget(m_userSettingsWindow);
+
+		// Re-create the settings window
+		String selSess = m_userSettingsWindow->selectedSession();
+		m_userSettingsWindow = UserMenu::create(this, userTable, userStatusTable, sessConfig->menu, theme, Rect2D::xywh(0.0f, 0.0f, 10.0f, 10.0f));
+		m_userSettingsWindow->setSelectedSession(selSess);
+		moveToCenter(m_userSettingsWindow);
+		m_userSettingsWindow->setVisible(true);
+
+		// Add the new settings window and clear the semaphore
+		addWidget(m_userSettingsWindow);
+		m_updateUserMenu = false;
+	}
+
+	GApp::onAfterEvents();
 }
 
 void App::onPostProcessHDR3DEffects(RenderDevice *rd) {

--- a/source/App.cpp
+++ b/source/App.cpp
@@ -203,8 +203,10 @@ void App::loadModels() {
 
 void App::updateControls() {
 	// Update the user settings window
+	removeWidget(m_userSettingsWindow);
 	m_userSettingsWindow->setConfig(sessConfig->menu);
-	
+	addWidget(m_userSettingsWindow);
+
 	// Update the waypoint manager
 	waypointManager->updateControls();
 

--- a/source/App.h
+++ b/source/App.h
@@ -68,6 +68,8 @@ protected:
 	int										m_currentDelayBufferIndex = 0;
 
     shared_ptr<UserMenu>					m_userSettingsWindow;				///< User settings window
+	bool									m_updateUserMenu = false;			///< Semaphore to indicate user settings needs update
+
 	shared_ptr<PlayerControls>				m_playerControls;					///< Player controls window (developer mode)
 	shared_ptr<RenderControls>				m_renderControls;					///< Render controls window (developer mode)
 	shared_ptr<WeaponControls>				m_weaponControls;					///< Weapon controls window (developer mode)
@@ -179,6 +181,7 @@ public:
 	virtual void onGraphics2D(RenderDevice* rd, Array<shared_ptr<Surface2D> >& surface2D) override;
 	virtual void onGraphics3D(RenderDevice* rd, Array<shared_ptr<Surface> >& surface) override;
 	virtual bool onEvent(const GEvent& e) override;
+	virtual void onAfterEvents() override;
 	virtual void onUserInput(UserInput* ui) override;
 	virtual void onCleanup() override;
     virtual void oneFrame() override;

--- a/source/GuiElements.cpp
+++ b/source/GuiElements.cpp
@@ -348,15 +348,7 @@ UserMenu::UserMenu(App* app, UserTable& users, UserStatusTable& userStatus, Menu
 	m_reticlePreviewTexture = Texture::createEmpty("FPSci::ReticlePreview", m_app->reticleTexture->width(), m_app->reticleTexture->height());
 	m_reticleBuffer = Framebuffer::create(m_reticlePreviewTexture);
 
-	m_parent = pane();
-	updateMenu(config);
-	pack();
-}
-
-void UserMenu::updateMenu(const MenuConfig& config) 
-{	
-	// Clear the menu
-	m_parent->removeAllChildren();
+	m_parent = pane();	
 
 	GuiTextureBox* logoTb = nullptr;
 
@@ -388,7 +380,7 @@ void UserMenu::updateMenu(const MenuConfig& config)
 	// User Settings Pane
 	if (config.showUserSettings) {
 		m_currentUserPane = m_parent->addPane("Current User Settings");
-		updateUserPane(config);
+		drawUserPane(config);
 	}
 
 	// Resume/Quite Pane
@@ -415,11 +407,8 @@ void UserMenu::updateMenu(const MenuConfig& config)
 	m_resumeQuitPane->pack();
 }
 
-void UserMenu::updateUserPane(const MenuConfig& config) 
+void UserMenu::drawUserPane(const MenuConfig& config) 
 {
-	// Clear the pane
-	m_currentUserPane->removeAllChildren();
-
 	// Basic user info
 	UserConfig* user = m_users.getCurrentUser();
 	m_currentUserPane->beginRow(); {
@@ -602,7 +591,6 @@ void UserMenu::updateUserPress() {
 		String userId = m_userDropDown->get(m_ddCurrUserIdx);
 		m_users.currentUser = userId;
 		m_lastUserIdx = m_ddCurrUserIdx;
-		updateUserPane(m_config);
 		
 		// Update (selected) sessions
 		String sessId = updateSessionDropDown()[0];

--- a/source/GuiElements.h
+++ b/source/GuiElements.h
@@ -134,8 +134,7 @@ protected:
 
 	UserMenu(App* app, UserTable& users, UserStatusTable& userStatus, MenuConfig& config, const shared_ptr<GuiTheme>& theme, const Rect2D& rect);
 
-	void updateMenu(const MenuConfig& config);
-	void updateUserPane(const MenuConfig& config);
+	void drawUserPane(const MenuConfig& config);
 
 	void updateUserPress();
 	void updateSessionPress();
@@ -172,11 +171,4 @@ public:
 	shared_ptr<UserConfig> getCurrUser() {
 		return m_users.getUserById(selectedUserID());
 	}
-
-	void setConfig(const MenuConfig& config) { 
-		m_config = config; 
-		updateMenu(config);		// Redraw the menu w/ the new config
-	}
-
-
 };

--- a/source/GuiElements.h
+++ b/source/GuiElements.h
@@ -165,7 +165,7 @@ public:
 	}
 
 	String selectedUserID() const {
-		return m_userDropDown->get(m_ddCurrSessIdx);
+		return m_userDropDown->get(m_ddCurrUserIdx);
 	}
 
 	shared_ptr<UserConfig> getCurrUser() {


### PR DESCRIPTION
This fix moves to "recreation" of the `UserMenu` rather than attempting to "update it in place" when a new user/session is selected. This solves a set of issues introduced by the user menu refactor in commit [2617d1](https://github.com/NVlabs/abstract-fps/commit/2617d1d6472e3ad800489aa4ac2932529e7feeab).

The user menu is now recreated on user/session update and uses semaphore-based message passing to avoiding doing this recreation directly in the callback of the button press (from within the window). This also adds an App-specific `App::onAfterEvents()` to the set of `GApp` functions implemented by the FPSci app.

Merging this request closes #141 
