### PR TITLE
Automatic session progression

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -378,6 +378,8 @@ These flags control the display of the in-game user menu:
 |`allowReticleColorChange`          |`bool`     |Allow the user to change the color of their reticle (pre/post shot)    |
 |`allowReticleChangeTimeChange`     |`bool`     |Allow the user to change the time it takes to change the color and size of the reticle following a shot |
 |`showReticlePreview`               |`bool`     |Show the user a preview of their (pre-shot) reticle (size is not applied) | 
+|`showMenuOnStartup`                |`bool`     |Controls whether the user menu is shown at startup (should only be set at the experiment level)|
+|`showMenuBetweenSessions`          |`bool`     |Controls whether the user menu is shown between sessions (can be controlled on a per-session basis)|
 
 ```
 "showMenuLogo": true,                   // Show the logo
@@ -393,7 +395,9 @@ These flags control the display of the in-game user menu:
 "allowReticleSizeChange": true,         // If reticle changes are enabled, allow size changes
 "allowReticleColorChange": true,        // If reticle changes are enabled, allow color changes
 "allowReticleTimeChange": false,        // Even if reticle change is enabled, don't allow "shrink time" to change
-"showReticlePreview": true              // If reticle changes are enabled show the preview
+"showReticlePreview": true,             // If reticle changes are enabled show the preview
+"showMenuOnStartup" : true,             // Show the user menu when the application starts
+"showMenuBetweenSessions": true         // Show the user menu between each session
 ```
 
 ## Logger Config

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1538,6 +1538,9 @@ public:
 	bool allowReticleChangeTimeChange	= false;						///< Allow the user to change the reticle change time
 	bool showReticlePreview				= true;							///< Show a preview of the reticle
 
+	bool showMenuOnStartup				= true;							///< Show the user menu on startup?
+	bool showMenuBetweenSessions		= true;							///< Show the user menu between session?
+
 	void load(AnyTableReader reader, int settingsVersion = 1) {
 		switch (settingsVersion) {
 		case 1:
@@ -1555,6 +1558,8 @@ public:
 			reader.getIfPresent("allowReticleColorChange", allowReticleColorChange);
 			reader.getIfPresent("allowReticleChangeTimeChange", allowReticleChangeTimeChange);
 			reader.getIfPresent("showReticlePreview", showReticlePreview);
+			reader.getIfPresent("showMenuOnStartup", showMenuOnStartup);
+			reader.getIfPresent("showMenuBetweenSessions", showMenuBetweenSessions);
 			break;
 		default:
 			throw format("Did not recognize settings version: %d", settingsVersion);
@@ -1579,6 +1584,8 @@ public:
 		if (forceAll || def.allowReticleColorChange != allowReticleColorChange)				a["allowReticleColorChange"] = allowReticleColorChange;
 		if (forceAll || def.allowReticleChangeTimeChange != allowReticleChangeTimeChange)	a["allowReticleChangeTimeChange"] = allowReticleChangeTimeChange;
 		if (forceAll || def.showReticlePreview != showReticlePreview)						a["showReticlePreview"] = showReticlePreview;
+		if (forceAll || def.showMenuOnStartup != showMenuOnStartup)							a["showMenuOnStartup"] = showMenuOnStartup;
+		if (forceAll || def.showMenuBetweenSessions != showMenuBetweenSessions)				a["showMenuBetweenSessions"] = showMenuBetweenSessions;
 		return a;
 	}
 };

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -209,9 +209,10 @@ void FPSciApp::loadModels() {
 	}
 }
 
-void FPSciApp::updateControls() {
+void FPSciApp::updateControls(bool firstSession) {
 	// Update the user settings window
 	m_updateUserMenu = true;
+	if(!firstSession) m_showUserMenu = sessConfig->menu.showMenuBetweenSessions;
 
 	// Update the waypoint manager
 	waypointManager->updateControls();
@@ -262,6 +263,7 @@ void FPSciApp::makeGUI() {
 
 	// Add the control panes here
 	updateControls();
+	m_showUserMenu = experimentConfig.menu.showMenuOnStartup;
 }
 
 void FPSciApp::exportScene() {
@@ -356,7 +358,7 @@ void FPSciApp::updateSession(const String& id) {
 	}
 
 	// Update the controls for this session
-	updateControls();
+	updateControls(m_firstSession);				// If first session consider showing the menu
 
 	// Update the frame rate/delay
 	updateParameters(sessConfig->render.frameDelay, sessConfig->render.frameRate);
@@ -451,6 +453,10 @@ void FPSciApp::updateSession(const String& id) {
 	}
 	else {
 		logPrintf("Created results file: %s.db\n", logName.c_str());
+	}
+
+	if (m_firstSession) {
+		m_firstSession = false;
 	}
 }
 
@@ -768,7 +774,7 @@ void FPSciApp::onAfterEvents() {
 		m_userSettingsWindow = UserMenu::create(this, userTable, userStatusTable, sessConfig->menu, theme, Rect2D::xywh(0.0f, 0.0f, 10.0f, 10.0f));
 		m_userSettingsWindow->setSelectedSession(selSess);
 		moveToCenter(m_userSettingsWindow);
-		m_userSettingsWindow->setVisible(true);
+		m_userSettingsWindow->setVisible(m_showUserMenu);
 
 		// Add the new settings window and clear the semaphore
 		addWidget(m_userSettingsWindow);

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -69,6 +69,9 @@ protected:
 
     shared_ptr<UserMenu>					m_userSettingsWindow;				///< User settings window
 	bool									m_updateUserMenu = false;			///< Semaphore to indicate user settings needs update
+	bool									m_showUserMenu = true;				///< Show the user menu after update?
+
+	bool									m_firstSession = true;
 
 	shared_ptr<PlayerControls>				m_playerControls;					///< Player controls window (developer mode)
 	shared_ptr<RenderControls>				m_renderControls;					///< Render controls window (developer mode)
@@ -76,7 +79,7 @@ protected:
 
 	/** Called from onInit */
 	void makeGUI();
-	void updateControls();
+	void updateControls(bool firstSession = false);
 	virtual void loadModels();
 
 	/** Move a window to the center of the display */

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -304,7 +304,6 @@ void Session::updatePresentationState()
 	else if (currentState == PresentationState::scoreboard) {
 		//if (stateElapsedTime > m_scoreboardDuration) {
 			newState = PresentationState::complete;
-			m_app->openUserSettingsWindow();
 			if (m_hasSession) {
 				m_app->userSaveButtonPress();												// Press the save button for the user...
 				Array<String> remaining = m_app->updateSessionDropDown();


### PR DESCRIPTION
This branch implements flags for control over whether:

* The user menu is open at app startup (`showMenuOnStartup`)
* The user menu is opened automatically at the end of each session (`showMenuBetweenSessions`)

Merging this pull request closes #151 