### PR TITLE
Center the question dialog(s) on top of user menu

### DIFF
--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -293,6 +293,8 @@ void FPSciApp::userSaveButtonPress(void) {
 }	
 
 void FPSciApp::presentQuestion(Question question) {
+	openUserSettingsWindow();
+
 	switch (question.type) {
 	case Question::Type::MultipleChoice:
 		dialog = SelectionDialog::create(question.prompt, question.options, theme, question.title);
@@ -307,8 +309,9 @@ void FPSciApp::presentQuestion(Question question) {
 		throw "Unknown question type!";
 		break;
 	}
+
+	moveToCenter(dialog);
 	this->addWidget(dialog);
-	openUserSettingsWindow();
 }
 
 void FPSciApp::markSessComplete(String sessId) {

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -123,6 +123,7 @@ void FPSciApp::updateMouseSensitivity() {
 }
 
 void FPSciApp::setDirectMode(bool enable) {
+	m_mouseDirectMode = enable;
 	const shared_ptr<FirstPersonManipulator>& fpm = dynamic_pointer_cast<FirstPersonManipulator>(cameraManipulator());
 	fpm->setMouseMode(enable ? FirstPersonManipulator::MOUSE_DIRECT : FirstPersonManipulator::MOUSE_DIRECT_RIGHT_BUTTON);
 }
@@ -293,8 +294,6 @@ void FPSciApp::userSaveButtonPress(void) {
 }	
 
 void FPSciApp::presentQuestion(Question question) {
-	openUserSettingsWindow();
-
 	switch (question.type) {
 	case Question::Type::MultipleChoice:
 		dialog = SelectionDialog::create(question.prompt, question.options, theme, question.title);
@@ -312,6 +311,7 @@ void FPSciApp::presentQuestion(Question question) {
 
 	moveToCenter(dialog);
 	this->addWidget(dialog);
+	setDirectMode(false);
 }
 
 void FPSciApp::markSessComplete(String sessId) {
@@ -578,7 +578,6 @@ void FPSciApp::onSimulation(RealTime rdt, SimTime sdt, SimTime idt) {
 	// make sure mouse sensitivity is set right
 	if (m_userSettingsWindow->visible()) {
 		updateMouseSensitivity();
-		//m_userSettingsWindow->setVisible(m_userSettingsMode);		// Make sure window stays coherent w/ user settings mode
 	}
 
 	// Simulate the projectiles
@@ -1127,7 +1126,7 @@ void FPSciApp::onUserInput(UserInput* ui) {
 	(void)ui;
 
 	const shared_ptr<PlayerEntity>& player = scene()->typedEntity<PlayerEntity>("player");
-	if (!m_userSettingsWindow->visible() && notNull(player)) {
+	if (m_mouseDirectMode && notNull(player)) {
 		player->updateFromInput(ui);
 	}
 	else if (notNull(player)) {	// Zero the player velocity and rotation when in the setting menu

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -68,6 +68,7 @@ protected:
 	int										m_currentDelayBufferIndex = 0;
 
     shared_ptr<UserMenu>					m_userSettingsWindow;				///< User settings window
+	bool									m_mouseDirectMode = true;			///< Does the mouse currently have control over the view
 	bool									m_updateUserMenu = false;			///< Semaphore to indicate user settings needs update
 	bool									m_showUserMenu = true;				///< Show the user menu after update?
 


### PR DESCRIPTION
Center dialog boxes used to ask users questions following a session. Consider adding support for optional opening of the user menu when questions are asked as well.

Merging this PR closes #158.