### PR TITLE
Fix start with all of current user's sessions complete

### DIFF
--- a/source/GuiElements.h
+++ b/source/GuiElements.h
@@ -156,6 +156,7 @@ public:
 	}
 
 	String selectedSession() const {
+		if (m_ddCurrSessIdx == -1) return "";
 		return m_sessDropDown->get(m_ddCurrSessIdx);
 	}
 


### PR DESCRIPTION
Quick fix to solve for starting the application with the user config's `currentUser` set to a user who has all sessions completed.

Merging this PR closes #157.