### PR TITLE
Update user config on user change in application

### DIFF
--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -463,11 +463,13 @@ public:
 			UserTable defTable = UserTable();
 			defTable.users.append(UserConfig());			// Append one default user
 			defTable.currentUser = defTable.users[0].id;	// Set this as the current user
-			defTable.toAny().save("userconfig.Any");		// Save the .any file
+			defTable.save(filename);						// Save the .any file
 			return defTable;
 		}
 		return Any::fromFile(System::findDataFile(filename));
 	}
+
+	inline void save(String filename) { toAny().save(filename); }
 
 	/** Print the user table to the log */
 	void printToLog() {

--- a/source/GuiElements.cpp
+++ b/source/GuiElements.cpp
@@ -590,14 +590,17 @@ void UserMenu::updateUserPress() {
 	if (m_lastUserIdx != m_ddCurrUserIdx) {
 		// Update user ID
 		String userId = m_userDropDown->get(m_ddCurrUserIdx);
+
+		// Update the current user and save to the user config file
 		m_users.currentUser = userId;
+		m_users.save(m_app->startupConfig.userConfig());
+
 		m_lastUserIdx = m_ddCurrUserIdx;
 		
 		// Update (selected) sessions
 		String sessId = updateSessionDropDown()[0];
 		if (m_sessDropDown->numElements() > 0) m_app->updateSession(sessId);
 	}
-	//updateSessionDropDown();
 }
 
 void UserMenu::updateReticlePreview() {


### PR DESCRIPTION
This branch implements two changes around the `UserTable` structure and it's interaction with the in-app user menu.

1. The user config file is now saved in accordance with the `userConfigPath` provided in the startup config Any file and it's corresponding `StartupConfig::userConfig()` accessor.
2. The user config file's `currentUser` field is now updated/saved whenever the user presses the "Select User" button within the GUI.

Merging this PR closes #160.