### PR TITLE
Experiment designer control of whether to show reference target

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -298,6 +298,7 @@ These flags help control the behavior of click-to-photon monitoring in applicati
 | Parameter Name        |Units                  | Description                                                                        |
 |-----------------------|-----------------------|------------------------------------------------------------------------------------|
 |`targetHealthColors`   |[`Color3`, `Color3`]   | The max/min health colors for the target as an array of [`max color`, `min color`], if you do not want the target to change color as its health drops, set these values both to the same color                                              |
+|`showRefTarget`        |`bool`                 | Show a reference target to re-center the view between trials/sessions?             |
 |`referenceTargetColor` |`Color3`               | The color of the "reference" targets spawned between trials                        |
 |`referenceTargetSize`  |m                      | The size of the "reference" targets spawned between trials                         |
 
@@ -307,6 +308,7 @@ These flags help control the behavior of click-to-photon monitoring in applicati
     Color3(0.0, 1.0, 0.0),
     Color3(1.0, 0.0, 0.0)
 ],
+"showRefTarget": true,                          // Show a reference target between trials
 "referenceTargetColor": Color3(1.0,1.0,1.0),    // Reference target color (return to "0" view direction)
 "referenceTargetSize": 0.01,                    // This is a size in meters
 ```

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -298,7 +298,7 @@ These flags help control the behavior of click-to-photon monitoring in applicati
 | Parameter Name        |Units                  | Description                                                                        |
 |-----------------------|-----------------------|------------------------------------------------------------------------------------|
 |`targetHealthColors`   |[`Color3`, `Color3`]   | The max/min health colors for the target as an array of [`max color`, `min color`], if you do not want the target to change color as its health drops, set these values both to the same color                                              |
-|`showRefTarget`        |`bool`                 | Show a reference target to re-center the view between trials/sessions?             |
+|`showReferencTarget`   |`bool`                 | Show a reference target to re-center the view between trials/sessions?             |
 |`referenceTargetColor` |`Color3`               | The color of the "reference" targets spawned between trials                        |
 |`referenceTargetSize`  |m                      | The size of the "reference" targets spawned between trials                         |
 
@@ -308,7 +308,7 @@ These flags help control the behavior of click-to-photon monitoring in applicati
     Color3(0.0, 1.0, 0.0),
     Color3(1.0, 0.0, 0.0)
 ],
-"showRefTarget": true,                          // Show a reference target between trials
+"showReferenceTarget": true,                    // Show a reference target between trials
 "referenceTargetColor": Color3(1.0,1.0,1.0),    // Reference target color (return to "0" view direction)
 "referenceTargetSize": 0.01,                    // This is a size in meters
 ```

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -35,16 +35,18 @@ The `weapon` config should be thought of as an atomic type (just like an `int` o
 ## Duration Settings
 The following settings allow the user to control various timings/durations around the per trial state machine.
 
-| Parameter Name     |Units| Description                                                        |
-|--------------------|-----|--------------------------------------------------------------------|
-|`feedbackDuration`  |s    |The duration of the feedback window between experiments             |
-|`readyDuration`     |s    |The time before the start of each trial                             |
-|`taskDuration`      |s    |The maximum time over which the task can occur                      |
+| Parameter Name      |Units| Description                                                        |
+|---------------------|-----|--------------------------------------------------------------------|
+|`readyDuration`      |s    |The time before the start of each trial                             |
+|`taskDuration`       |s    |The maximum time over which the task can occur                      |
+|`feedbackDuration`   |s    |The duration of the feedback window between trials                  |
+|`scoreboardDuration` |s    |The duration of the feedback window between sessions                |
 
 ```
-"feedbackDuration": 1.0,    // Time allocated for providing user feedback
-"readyDuration": 0.5,       // Time allocated for preparing for trial
-"taskDuration": 100000.0,   // Maximum duration allowed for completion of the task
+"readyDuration": 0.5,         // Time allocated for preparing for trial
+"taskDuration": 100000.0,     // Maximum duration allowed for completion of the task
+"feedbackDuration": 1.0,      // Time for user feedback between trials
+"scoreboardDuration": 5.0,    // Time for user feedback between sessions
 ```
 
 ## Rendering Settings

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1323,6 +1323,7 @@ public:
 	float           combatTextTimeout = 0.5f;							///< Time for combat text to disappear (in seconds)
 
 	// Reference/dummy target
+	bool			showRefTarget = true;								///< Show the reference target?
 	float           refTargetSize = 0.05f;								///< Size of the reference target
 	Color3          refTargetColor = Color3(1.0, 0.0, 0.0);				///< Default reference target color
 
@@ -1345,6 +1346,7 @@ public:
 			reader.getIfPresent("floatingCombatTextVelocity", combatTextVelocity);
 			reader.getIfPresent("floatingCombatTextFade", combatTextFade);
 			reader.getIfPresent("floatingCombatTextTimeout", combatTextTimeout);
+			reader.getIfPresent("showRefTarget", showRefTarget);
 			reader.getIfPresent("referenceTargetSize", refTargetSize);
 			reader.getIfPresent("referenceTargetColor", refTargetColor);
 			break;
@@ -1372,6 +1374,7 @@ public:
 		if(forceAll || def.combatTextVelocity != combatTextVelocity)		a["floatingCombatTextVelocity"] = combatTextVelocity;
 		if(forceAll || def.combatTextFade != combatTextFade)				a["floatingCombatTextFade"] = combatTextFade;
 		if(forceAll || def.combatTextTimeout != combatTextTimeout)			a["floatingCombatTextTimeout"] = combatTextTimeout;
+		if (forceAll || def.showRefTarget != showRefTarget)					a["showRefTarget"] = showRefTarget;
 		if(forceAll || def.refTargetSize != refTargetSize)					a["referenceTargetSize"] = refTargetSize;
 		if(forceAll || def.refTargetColor != refTargetColor)				a["referenceTargetColor"] = refTargetColor;
 		return a;

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1453,6 +1453,7 @@ public:
 	float           readyDuration = 0.5f;						///< Time in ready state in seconds
 	float           taskDuration = 100000.0f;					///< Maximum time spent in any one task
 	float           feedbackDuration = 1.0f;					///< Time in feedback state in seconds
+	float			scoreboardDuration = 5.0f;					///< Time in scoreboard state in seconds
 	// Trial count
 	int             defaultTrialCount = 5;						///< Default trial count
 
@@ -1462,6 +1463,7 @@ public:
 			reader.getIfPresent("feedbackDuration", feedbackDuration);
 			reader.getIfPresent("readyDuration", readyDuration);
 			reader.getIfPresent("taskDuration", taskDuration);
+			reader.getIfPresent("scoreboardDuration", scoreboardDuration);
 			reader.getIfPresent("defaultTrialCount", defaultTrialCount);
 			break;
 		default:

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1346,7 +1346,7 @@ public:
 			reader.getIfPresent("floatingCombatTextVelocity", combatTextVelocity);
 			reader.getIfPresent("floatingCombatTextFade", combatTextFade);
 			reader.getIfPresent("floatingCombatTextTimeout", combatTextTimeout);
-			reader.getIfPresent("showRefTarget", showRefTarget);
+			reader.getIfPresent("showReferenceTarget", showRefTarget);
 			reader.getIfPresent("referenceTargetSize", refTargetSize);
 			reader.getIfPresent("referenceTargetColor", refTargetColor);
 			break;

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -71,7 +71,9 @@ bool Session::updateBlock(bool updateTargets) {
 void Session::onInit(String filename, String description) {
 	// Initialize presentation states
 	presentationState = PresentationState::initial;
-	m_feedbackMessage = "Click to spawn a target, then use shift on red target to begin.";
+	m_feedbackMessage = m_config->targetView.showRefTarget ? 
+		"Click to spawn a target, then use shift on red target to begin." : 
+		"Click to start the session!";
 
 	// Get the player from the app
 	m_player = m_app->scene()->typedEntity<PlayerEntity>("player");
@@ -285,9 +287,7 @@ void Session::updatePresentationState()
 					}
 					else {
 						if (m_config->logger.enable) {
-							m_logger->logUserConfig(*m_app->getCurrUser(), m_config->id, "end");
-							m_logger->flush(false);
-							m_logger.reset();
+							endLogging();
 						}
 						m_app->markSessComplete(m_config->id);														// Add this session to user's completed sessions
 
@@ -343,7 +343,7 @@ void Session::updatePresentationState()
 		}
 		presentationState = newState;
 		//If we switched to task, call initTargetAnimation to handle new trial
-		if ((newState == PresentationState::task) || (newState == PresentationState::feedback)) {
+		if ((newState == PresentationState::task) || (newState == PresentationState::feedback && m_config->targetView.showRefTarget)) {
 			initTargetAnimation();
 		}
 	}
@@ -474,6 +474,8 @@ String Session::getFeedbackMessage() {
 
 void Session::endLogging() {
 	if (m_logger != nullptr) {
+		m_logger->logUserConfig(*m_app->getCurrUser(), m_config->id, "end");
+		m_logger->flush(false);
 		m_logger.reset();
 	}
 }

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -313,7 +313,7 @@ void Session::updatePresentationState()
 		}
 	}
 	else if (currentState == PresentationState::scoreboard) {
-		//if (stateElapsedTime > m_scoreboardDuration) {
+		if (stateElapsedTime > m_config->timing.scoreboardDuration) {
 			newState = PresentationState::complete;
 			if (m_hasSession) {
 				m_app->userSaveButtonPress();												// Press the save button for the user...
@@ -330,6 +330,7 @@ void Session::updatePresentationState()
 			else {
 				m_feedbackMessage = "All Sessions Complete!";							// Update the feedback message
 				moveOn = false;
+			}
 		}
 	}
 

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -71,9 +71,11 @@ bool Session::updateBlock(bool updateTargets) {
 void Session::onInit(String filename, String description) {
 	// Initialize presentation states
 	presentationState = PresentationState::initial;
-	m_feedbackMessage = m_config->targetView.showRefTarget ? 
-		"Click to spawn a target, then use shift on red target to begin." : 
-		"Click to start the session!";
+	if (m_config) {
+		m_feedbackMessage = m_config->targetView.showRefTarget ?
+			"Click to spawn a target, then use shift on red target to begin." :
+			"Click to start the session!";
+	}
 
 	// Get the player from the app
 	m_player = m_app->scene()->typedEntity<PlayerEntity>("player");

--- a/source/Session.h
+++ b/source/Session.h
@@ -140,7 +140,6 @@ protected:
 	String m_taskStartTime;								///< Recorded task start timestamp							
 	String m_taskEndTime;								///< Recorded task end timestamp
 	RealTime m_totalRemainingTime = 0;					///< Time remaining in the trial
-	RealTime m_scoreboardDuration = 10.0;				///< Show the score for at least this amount of seconds.
 	RealTime m_lastFireAt = 0.f;						///< Time of the last shot
 	Timer m_timer;										///< Timer used for timing tasks	
 	// Could move timer above to stopwatch in future


### PR DESCRIPTION
This branch implements the `showRefTarget` flag for session/experiment level configuration that allows the user to specify that the reference target (not) be drawn between trials within the session.

Merging this PR closes #164.