### PR TITLE
Add automatic closing of app on experiment/session end

### DIFF
--- a/docs/experimentConfigReadme.md
+++ b/docs/experimentConfigReadme.md
@@ -18,8 +18,10 @@ The `experimentconfig.Any` file is located in the [`data-files`](../data-files/)
 The experment config supports inclusion of any of the configuration parameters documented in the [general configuration parameter guide](general_config.md). In addition to these common parameters, there are a number of unique inputs to experiment config. The following is a description of what each one means, and how it is meant to be used.
 
 * `description` allows the user to annotate this experiment's results with a custom string
+* `closeOnComplete` closes the application once all sessions from the sessions array (defined below) are complete 
 ```
 "description": "your description here",    // Description of this file (default = "default")
+"closeOnComplete": false,                  // Don't close automatically when all sessions are complete
 ```
 
 ### Session Configuration
@@ -28,6 +30,7 @@ Each session can specify any of the [general configuration parameters](general_c
 * `sessions` is a list of all sessions and their affiliated information:
     * `session id` is a short name for the session
     * `description` is used to indicate an additional mode for affiliated sessions (such as `real` vs `training`)
+    * `closeOnComplete` signals to close the application whenever this session (in particular) is completed
     * `blockCount` is an integer number of (repeated) groups of trials within a session, with the block number printed to the screen between "blocks" (or a single "default" block if not provided).
     * `trials` is a list of trials referencing the `trials` table above:
         * `ids` is a list of short names for the trial(s) to affiliate with the `targets` or `reactions` table below, if multiple ids are provided multiple target are spawned simultaneously in each trial
@@ -41,6 +44,7 @@ An example session configuration snippet is included below:
     {
         "id" : "test-session",          // This is a short name for our session
         "description" : "test",         // This is an arbitrary string tag (for now)
+        "closeOnComplete": false,       // Don't automatically close the application when the session completes
         "frameRate" : 120,              // Example of a generic parameter modified for this session
         "blockCount" : 1,         // Single block design
         "trials" : [

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1672,6 +1672,7 @@ public:
 	String				description = "Session";		///< String indicating whether session is training or real
 	int					blockCount = 1;					///< Default to just 1 block per session
 	Array<TrialCount>	trials;							///< Array of trials (and their counts) to be performed
+	bool				closeOnComplete = false;		///< Close application on session completed?
 	static FpsConfig	defaultConfig;
 
 	SessionConfig() : FpsConfig(defaultConfig) {}
@@ -1689,6 +1690,7 @@ public:
 			// Unique session info
 			reader.get("id", id, "An \"id\" field must be provided for each session!");
 			reader.getIfPresent("description", description);
+			reader.getIfPresent("closeOnComplete", closeOnComplete);
 			reader.getIfPresent("blockCount", blockCount);
 			reader.get("trials", trials, format("Issues in the (required) \"trials\" array for session: \"%s\"", id));
 			break;
@@ -1705,6 +1707,7 @@ public:
 		// Update w/ the session-specific fields
 		a["id"] = id;
 		a["description"] = description;
+		a["closeOnComplete"] = closeOnComplete;
 		a["blockCount"] = blockCount;
 		a["trials"] = trials;
 		return a;
@@ -1731,6 +1734,7 @@ public:
 	String description = "Experiment";					///< Experiment description
 	Array<SessionConfig> sessions;						///< Array of sessions
 	Array<TargetConfig> targets;						///< Array of trial configs   
+	bool closeOnComplete = false;						///< Close application on all sessions complete
 
 	ExperimentConfig() { init(); }
 	
@@ -1743,6 +1747,7 @@ public:
 			SessionConfig::defaultConfig = (FpsConfig)(*this);												// Setup the default configuration here
 			// Experiment-specific info
 			reader.getIfPresent("description", description);
+			reader.getIfPresent("closeOnComplete", closeOnComplete);
 			reader.get("targets", targets, "Issue in the (required) \"targets\" array for the experiment!");	// Targets must be specified for the experiment
 			reader.get("sessions", sessions, "Issue in the (required) \"sessions\" array for the experiment config!");
 			break;
@@ -1883,6 +1888,7 @@ public:
 		SessionConfig def;
 		// Write the experiment configuration-specific 
 		if(forceAll || def.description != description) a["description"] = description;
+		if (forceAll || def.closeOnComplete != closeOnComplete) a["closeOnComplete"] = closeOnComplete;
 		a["targets"] = targets;
 		a["sessions"] = sessions;
 		return a;

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -319,15 +319,24 @@ void Session::updatePresentationState()
 				if (remaining.size() == 0) {
 					m_feedbackMessage = "All Sessions Complete!"; // Update the feedback message
 					moveOn = false;
+					if (m_app->experimentConfig.closeOnComplete || m_config->closeOnComplete) {
+						m_app->quitRequest();
+					}
 				}
 				else {
 					m_feedbackMessage = "Session Complete!"; // Update the feedback message
+					if (m_config->closeOnComplete) {
+						m_app->quitRequest();
+					}
 					moveOn = true;														// Check for session complete (signal start of next session)
 				}
 			}
 			else {
 				m_feedbackMessage = "All Sessions Complete!";							// Update the feedback message
 				moveOn = false;
+				if (m_app->experimentConfig.closeOnComplete) {
+					m_app->quitRequest();
+				}
 		}
 	}
 


### PR DESCRIPTION
This branch adds support for an (independent) session and experiment-level `closeOnComplete` flag. 

*The experiment-level `closeOnComplete` flag closes the application when _all sessions_ within the experiment are complete. This also closes the application when opened with no sessions remaining.
*The session-level `closeOnComplete` flag closes the application when the particular session it is specified on is complete. This allows a way for experiment designers to regulate the flow of users through various sessions.

Merging this PR closes #166.