### PR TITLE
Add requirement for click in addition to scoreboardDuration parameter

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -35,18 +35,20 @@ The `weapon` config should be thought of as an atomic type (just like an `int` o
 ## Duration Settings
 The following settings allow the user to control various timings/durations around the per trial state machine.
 
-| Parameter Name      |Units| Description                                                        |
-|---------------------|-----|--------------------------------------------------------------------|
-|`readyDuration`      |s    |The time before the start of each trial                             |
-|`taskDuration`       |s    |The maximum time over which the task can occur                      |
-|`feedbackDuration`   |s    |The duration of the feedback window between trials                  |
-|`scoreboardDuration` |s    |The duration of the feedback window between sessions                |
+| Parameter Name            |Units  | Description                                                        |
+|---------------------------|-------|--------------------------------------------------------------------|
+|`readyDuration`            |s      |The time before the start of each trial                             |
+|`taskDuration`             |s      |The maximum time over which the task can occur                      |
+|`feedbackDuration`         |s      |The duration of the feedback window between trials                  |
+|`scoreboardDuration`       |s      |The duration of the feedback window between sessions                |
+|`scoreboardRequireClick`   |`bool` |Require the user to click to move past the scoreboard (in addition to waiting the `scoreboardDuration`)|
 
 ```
 "readyDuration": 0.5,         // Time allocated for preparing for trial
 "taskDuration": 100000.0,     // Maximum duration allowed for completion of the task
 "feedbackDuration": 1.0,      // Time for user feedback between trials
 "scoreboardDuration": 5.0,    // Time for user feedback between sessions
+"scoreboardRequireClick" : false,      // Don't require a click to move past the scoreboard
 ```
 
 ## Rendering Settings

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1454,6 +1454,8 @@ public:
 	float           taskDuration = 100000.0f;					///< Maximum time spent in any one task
 	float           feedbackDuration = 1.0f;					///< Time in feedback state in seconds
 	float			scoreboardDuration = 5.0f;					///< Time in scoreboard state in seconds
+	bool			scoreboardRequireClick = false;				///< Require a click to progress from the scoreboard?
+
 	// Trial count
 	int             defaultTrialCount = 5;						///< Default trial count
 
@@ -1464,6 +1466,7 @@ public:
 			reader.getIfPresent("readyDuration", readyDuration);
 			reader.getIfPresent("taskDuration", taskDuration);
 			reader.getIfPresent("scoreboardDuration", scoreboardDuration);
+			reader.getIfPresent("scoreboardRequireClick", scoreboardRequireClick);
 			reader.getIfPresent("defaultTrialCount", defaultTrialCount);
 			break;
 		default:
@@ -1474,10 +1477,12 @@ public:
 
 	Any addToAny(Any a, bool forceAll = false) const {
 		TimingConfig def;
-		if(forceAll || def.feedbackDuration != feedbackDuration)	a["feedbackDuration"] = feedbackDuration;
-		if(forceAll || def.readyDuration != readyDuration)			a["readyDuration"] = readyDuration;
-		if(forceAll || def.taskDuration != taskDuration)			a["taskDuration"] = taskDuration;
-		if(forceAll || def.defaultTrialCount != defaultTrialCount)	a["defaultTrialCount"] = defaultTrialCount;
+		if(forceAll || def.feedbackDuration != feedbackDuration)		a["feedbackDuration"] = feedbackDuration;
+		if(forceAll || def.readyDuration != readyDuration)				a["readyDuration"] = readyDuration;
+		if(forceAll || def.taskDuration != taskDuration)				a["taskDuration"] = taskDuration;
+		if(forceAll || def.scoreboardDuration != scoreboardDuration)	a["scoreboardDuration"] = scoreboardDuration;
+		if(forceAll || def.scoreboardRequireClick != scoreboardRequireClick) a["scoreboardRequireClick"] = scoreboardRequireClick;
+		if(forceAll || def.defaultTrialCount != defaultTrialCount)		a["defaultTrialCount"] = defaultTrialCount;
 		return a;
 	}
 };

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -323,7 +323,7 @@ void Session::updatePresentationState()
 	}
 	else if (currentState == PresentationState::scoreboard) {
 		if (m_hasSession) {
-			if (stateElapsedTime > m_config->timing.scoreboardDuration) {
+			if (stateElapsedTime > m_config->timing.scoreboardDuration && (!m_config->timing.scoreboardRequireClick || !m_app->m_buttonUp)) {
 				newState = PresentationState::complete;
 				m_app->userSaveButtonPress();				// Press the save button for the user...
 


### PR DESCRIPTION
This branch adds a `scoreboardRequireClick` parameter to the timing configuration that allows the experiment designer to require a left mouse click event to progress from the scoreboard state (in addition to the `scoreboardDuration` timing having expired.

Merging this request closes #179.