### PR TITLE
Doc fixes

### DIFF
--- a/docs/developermode.md
+++ b/docs/developermode.md
@@ -1,5 +1,5 @@
 # Developer Mode
-During development of `FirstPersonScience` we created a number of utilities for testing target motion and game play outside of the formal experiment definition. The `playMode` flag in [`startupconfig.Any`](../data-files/startupConfigReadme.md) controls whether the application is run in experiment "play" mode (`playMode=True`) or developer mode `(playMode=False`).
+During development of `FirstPersonScience` we created a number of utilities for testing target motion and game play outside of the formal experiment definition. The `developerMode` flag in [`startupconfig.Any`](../data-files/startupConfigReadme.md) controls whether the application is run in experiment "play" mode (`developerMode=False`) or developer mode `(developerMode=True`).
 
 ## Developer Mode Features
 When running in developer mode a number of the otherwise static features of the tool are available for dynamic toggle via an expanded Heads Up Display menu accessible during the normally available pause (Tab) menu.
@@ -18,7 +18,7 @@ Features include:
 * Initialization of player position and view direction
 
 ## Enabling Developer Mode
-As mentioned above, all that needs to be done to enabled developer mode is modifying the `playMode` field in [`startupconfig.Any`](../data-files/startupconfig.Any) to `True`, then running the application to enter developer mode.
+As mentioned above, all that needs to be done to enabled developer mode is modifying the `developerMode` field in [`startupconfig.Any`](../data-files/startupconfig.Any) to `True`, then running the application to enter developer mode.
 
 ## Player Position Initialization
 Once in developer mode the initial player position can be set by pressing `Esc` or `Tab` to enter the pause menu (pointer mode) then clicking the `Set Start Pos` button while positioned/aiming in your desired initial location/direction.

--- a/docs/developermode.md
+++ b/docs/developermode.md
@@ -21,4 +21,4 @@ Features include:
 As mentioned above, all that needs to be done to enabled developer mode is modifying the `developerMode` field in [`startupconfig.Any`](../data-files/startupconfig.Any) to `True`, then running the application to enter developer mode.
 
 ## Player Position Initialization
-Once in developer mode the initial player position can be set by pressing `Esc` or `Tab` to enter the pause menu (pointer mode) then clicking the `Set Start Pos` button while positioned/aiming in your desired initial location/direction.
+Once in developer mode the initial player position can be set by pressing the menu key (see `openMenu` [keymap](keymap.md)) to enter the pause menu (pointer mode) then clicking the `Set Start Pos` button while positioned/aiming in your desired initial location/direction.

--- a/docs/experimentConfigReadme.md
+++ b/docs/experimentConfigReadme.md
@@ -79,7 +79,7 @@ The `targets` array specifies a list of targets each of which can contain any/al
 The following configuration is universal to all target types.
 
 * `id` a short string to refer to this target information
-* `respawnCount` is an integer providing the number of respawns to occur. For non-respawning items use `0` or leave unspecified.
+* `respawnCount` is an integer providing the number of respawns to occur. For non-respawning items use `0` or leave unspecified. A value of `-1` creates a target that respawns infinitely (trial ends when ammo or task time runs out).
 * `visualSize` is a vector indicating the minimum ([0]) and maximum ([1]) visual size for the target (in deg)
 * `destSpace` the space for which the target is rendered (useful for non-destiantion based targets, "player" or "world")
 * `hitSound` is a filename for the sound to play when the target is hit but not destroyed.

--- a/docs/experimentConfigReadme.md
+++ b/docs/experimentConfigReadme.md
@@ -25,7 +25,9 @@ The experment config supports inclusion of any of the configuration parameters d
 ```
 
 ### Session Configuration
-Each session can specify any of the [general configuration parameters](general_config.md) used in the experiment config above to create experimental conditions. In addition to these general parameters each session also has a few unique parameters documented below.
+Each session can specify any of the [general configuration parameters](general_config.md) used in the experiment config above to create experimental conditions. If both the experiment level and the session level specify a field supported by the general configuration, the session value has priority and will be used for that session. The experiment level configuration will be used for any session that doesn't specify that parameter.
+
+In addition to these general parameters each session also has a few unique parameters documented below.
 
 * `sessions` is a list of all sessions and their affiliated information:
     * `session id` is a short name for the session

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -1,5 +1,5 @@
 # General Configuration Parameters
-FPSci offers a number of different [`.Any` file](./AnyFile.md) configurable parameters that can be set at either the "experiment" or "session" level. This document describes these parameters and gives examples of their usage.
+FPSci offers a number of different [`.Any` file](./AnyFile.md) configurable parameters that can be set at either the "experiment" or "session" level. This document describes these parameters and gives examples of their usage. Note that any value specified at both the "experiment" and "session" level will use the value specified by the session level.
 
 ## Settings Version
 | Parameter Name     |Units| Description                                                        |

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -300,7 +300,7 @@ These flags help control the behavior of click-to-photon monitoring in applicati
 | Parameter Name        |Units                  | Description                                                                        |
 |-----------------------|-----------------------|------------------------------------------------------------------------------------|
 |`targetHealthColors`   |[`Color3`, `Color3`]   | The max/min health colors for the target as an array of [`max color`, `min color`], if you do not want the target to change color as its health drops, set these values both to the same color                                              |
-|`showReferencTarget`   |`bool`                 | Show a reference target to re-center the view between trials/sessions?             |
+|`showReferenceTarget`   |`bool`                | Show a reference target to re-center the view between trials/sessions?             |
 |`referenceTargetColor` |`Color3`               | The color of the "reference" targets spawned between trials                        |
 |`referenceTargetSize`  |m                      | The size of the "reference" targets spawned between trials                         |
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -12,10 +12,10 @@ To start out with we don't have any of the required configuration files we will 
 ### Experiment Configuraion
 Generally speaking, when starting a new experiment design, it makes sense to start from the [`experimentconfig.Any` file](experimentConfigReadme.md). This file contains both the experiment-wide application parameters and the configurations for sessions and targets/trials within these sessions.
 
-There are 2 ways to get started on an `experimentconfig.Any` file. You can either start writing a file from scrath, or run the application the first time to produce the deafult `experimentconfig.Any` and edit from here.
+There are 2 ways to get started on an `experimentconfig.Any` file. You can either start writing a file from scratch, or run the application the first time to produce the default `experimentconfig.Any` and edit from here.
 
 #### General Configuration
-To begin with we need to specify the `settingsVersion` (used for parsing) as `1` (currently the only supported settings verison). We should also provide a `description` for the experiment.
+To begin with we need to specify the `settingsVersion` (used for parsing) as `1` (currently the only supported settings version). We should also provide a `description` for the experiment.
 
 ```
 {
@@ -50,7 +50,7 @@ To start with we will setup a simple target that uses the apps default target mo
 ```
 
 #### Adding Sessions
-Let's add a session to the experiment. We do this by creating a `sessions` array within the top-level experiment config. Within this `sessions` array we can add an insteance of a session. Within this session we can (again) modify any of the [general parameters](general_config.md).
+Let's add a session to the experiment. We do this by creating a `sessions` array within the top-level experiment config. Within this `sessions` array we can add an instance of a session. Within this session we can (again) modify any of the [general parameters](general_config.md).
 
 The only _required_ field within any given session configuration is the `trials` array. Which specifies a series of targets (using their `id` field) and counts for each of these targets.
 
@@ -69,7 +69,7 @@ The only _required_ field within any given session configuration is the `trials`
 ```
 
 ### Setting Up User Parameters
-User configuration is managed via 2 files ([`userconfig.Any`](userConfigReadme.md) and [`userstatus.Any`](userStatusReadme.md)). The [`userconfig.Any` file](userConfigReadme.md) specifies per-user settings (DPI and mouse sensitivity in cm/360°) as well as the `currentUser` (user to set as active when loading the app). All of these values are editable from within the application runtime.
+User configuration is managed via 2 files ([`userconfig.Any`](userConfigReadme.md) and [`userstatus.Any`](userStatusReadme.md)). The [`userconfig.Any` file](userConfigReadme.md) specifies per-user settings (DPI and mouse sensitivity in cm/360°). The `userstatus.Any` file specifies the `currentUser` (user to set as active when loading the app) and tracks the progress of each user through the experiment sessions. Many of these values are editable from within the application runtime.
 
 The [`userstatus.Any` file](userStatusReadme.md) tracks the `sessions` to be completed as well as the `completedSessions` for any given user. These values cannot be edited from within the application.
 
@@ -80,7 +80,6 @@ Let's create a single user for our new experiment. To do this we will start in t
 ```
 {
     settingsVersion: 1,
-    currentUser: "user",
     users = [
         {
             id: "user",
@@ -99,6 +98,7 @@ Now that we have a configuration for our new user, we can update the [`userstatu
 ```
 {
     settingsVersion: 1,
+    currentUser: "user",
     users = [
         {
             id: "user",

--- a/docs/keymap.md
+++ b/docs/keymap.md
@@ -2,10 +2,10 @@
 This file describes both the standard and custom key mapping/bindings for the application.
 
 ## Default Mapping
-The default key map for the application is split into 2 modes, "normal" mode (`playMode=true`) and "developer" mode (`playMode=false`). We outline commands for each mode below.
+The default key map for the application is split into 2 modes, "normal" mode (`developerMode=false`) and "developer" mode (`developerMode=true`). We outline commands for each mode below.
 
 ### Normal Mode
-When `playMode=true` the following keys are used:
+When `developerMode=false` the following keys are used:
 
 |Key Name       |Action                         |
 |---------------|-------------------------------|
@@ -21,7 +21,7 @@ When `playMode=true` the following keys are used:
 |`-`            |Quit the application           |
 
 ### Developer Mode
-When `playMode=false` the following keys/actions are available in addition to the "normal" key map above.
+When `developerMode=true` the following keys/actions are available in addition to the "normal" key map above.
 
 | Key Name  |Action                             |
 |-----------|-----------------------------------|
@@ -44,31 +44,31 @@ As an alternative to the standard key mappings provided above the user can chang
 This file associates each of the map names outlined below to an array of `GKey` strings indicating the key(s) that should be mapped to this action.
 
 
-|Action                             |Map Name               |Default Key(s)     |
-|-----------------------------------|-----------------------|-------------------|
-|Move forward                       |`moveForward`          |`["W", "Up"]`      |
-|Strafe left                        |`strafeLeft`           |`["A", "Left"]`    |
-|Move backward                      |`moveBackward`         |`["S", "Down"]`    |
-|Strafe right                       |`strafeRight`          |`["D", "Right"]`   |
-|Crouch                             |`crouch`               |`["L Ctrl"]`       |
-|Jump                               |`jump`                 |`["Spc"]`          |
-|Open in-game menu                  |`openMenu`             |`["Esc","Tab"]`    |
-|Fire the weapon during trial       |`shoot`                |`["L Mouse"]`      |
-|Use a scope                        |`scope`                |`["R Mouse"]`      |
-|Fire the weapon pre-trial          |`dummyShoot`           |`["R Shift"]`      |
-|Quit the application               |`quit`                 |`["-"]`            |
-|Drop a waypoint                    |`dropWaypoint`         |`["Q"]`            |
-|Record player motion as waypoints  |`toggleRecording`      |`["R"]`            |
-|Open the render control window     |`toggleRenderWindow`   |`["1"]`            |
-|Open the player control window     |`togglePlayerWindow`   |`["2"]`            |
-|Open the weapon control window     |`toggleWeaponWindow`   |`["3"]`            |
-|Open the waypoint control window   |`toggleWaypointWindow` |`["4"]`            |
-|Move waypoint up in space          |`moveWaypointUp`       |`["Pg Up"]`        |
-|Move waypoint down in space        |`moveWaypointDown`     |`["Pg Dn"]`        |
-|Move waypoint in in space          |`moveWaypointIn`       |`["Home"]`         |
-|Move waypoint out in space         |`moveWaypointOut`      |`["End"]`          |
-|Move waypoint right in space       |`moveWaypointRight`    |`["Ins"]`          |
-|Move waypoint left in space        |`moveWaypointLeft`     |`["Del"]`          |
+|Action                             |Map Name               |Default Key(s)         |
+|-----------------------------------|-----------------------|-----------------------|
+|Move forward                       |`moveForward`          |`["W", "Up"]`          |
+|Strafe left                        |`strafeLeft`           |`["A", "Left"]`        |
+|Move backward                      |`moveBackward`         |`["S", "Down"]`        |
+|Strafe right                       |`strafeRight`          |`["D", "Right"]`       |
+|Crouch                             |`crouch`               |`["L Ctrl"]`           |
+|Jump                               |`jump`                 |`["Spc"]`              |
+|Open in-game menu                  |`openMenu`             |`["Esc"]`              |
+|Fire the weapon during trial       |`shoot`                |`["L Mouse"]`          |
+|Use a scope                        |`scope`                |`["R Mouse"]`          |
+|Fire the weapon pre-trial          |`dummyShoot`           |`["R Shift"]`          |
+|Quit the application               |`quit`                 |`["Keypad -", "Pause"]`|
+|Drop a waypoint                    |`dropWaypoint`         |`["Q"]`                |
+|Record player motion as waypoints  |`toggleRecording`      |`["R"]`                |
+|Open the render control window     |`toggleRenderWindow`   |`["1"]`                |
+|Open the player control window     |`togglePlayerWindow`   |`["2"]`                |
+|Open the weapon control window     |`toggleWeaponWindow`   |`["3"]`                |
+|Open the waypoint control window   |`toggleWaypointWindow` |`["4"]`                |
+|Move waypoint up in space          |`moveWaypointUp`       |`["Pg Up"]`            |
+|Move waypoint down in space        |`moveWaypointDown`     |`["Pg Dn"]`            |
+|Move waypoint in in space          |`moveWaypointIn`       |`["Home"]`             |
+|Move waypoint out in space         |`moveWaypointOut`      |`["End"]`              |
+|Move waypoint right in space       |`moveWaypointRight`    |`["Ins"]`              |
+|Move waypoint left in space        |`moveWaypointLeft`     |`["Del"]`              |
 
 ### GKey Strings
 The table below provides some useful macros for mapping `String` --> `GKey`. Whenever you are referring to a "normal" character key, be sure to use upper case letters!

--- a/docs/patheditor.md
+++ b/docs/patheditor.md
@@ -49,7 +49,7 @@ To preview a path with a default target model, press the `Preview` button at any
 If you modify a path during a preview it is suggested that you stop/restart the preview to see the newest path.
 
 ### Player Motion Recording
-Player motion recording is configured within the waypoint manager window in the developer mode (`playMode=False`) of the application. Once configured, recording can be toggled using the `R` key and a visual indicator for recording is presented in the top right of the display.
+Player motion recording is configured within the waypoint manager window in the developer mode (`developerMode=true`) of the application. Once configured, recording can be toggled using the `R` key and a visual indicator for recording is presented in the top right of the display.
 
 #### Motion Recording Modes
 Player motion can be recorded in two different modalities with the application:

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -12,6 +12,7 @@ Configuration
     * [`userconfig.Any`](userConfigReadme.md)
     * [`userstatus.Any`](userStatusReadme.md)
     * [`.weapon.Any` files](weaponConfigReadme.md)
+    * [`keymap.Any`](keymap.md)
 
 # Development
 FPSci gives you full source level control over modifying its functionality however you'd like. The "parent" readme below will help you get started with building FPSci from source. The Developer Mode and Path Editor are tools that can be helpful for experiment designers or software developers.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,9 +1,8 @@
 # Documentation
-Right now documentation on `FirstPersonScience` is somewhat limited. This space is an opportunity to increase/improve documentation for various features throughout the tool.
+Welcome to the `FirstPersonScience` Documentation! The experiment design is primarily controlled through a series of text files using the `.Any` extension and file format. As an experiment designer, you'll want to familiarize yourself with the format somewhat, then take a look at the configuration file descriptions from the list below to understand how to configure the various components of the experiment. The bulk of the experiment design is controlled through the `experimentconfig.Any` file.
 
-Directory
+Configuration
 ---
-* Parent [readme.md](../readme.md) has many useful links
 * [`.Any` file introduction](./AnyFile.md)
 * Configuration file descriptions:
     * [General parameters](general_config.md)
@@ -13,5 +12,10 @@ Directory
     * [`userconfig.Any`](userConfigReadme.md)
     * [`userstatus.Any`](userStatusReadme.md)
     * [`.weapon.Any` files](weaponConfigReadme.md)
+
+# Development
+FPSci gives you full source level control over modifying its functionality however you'd like. The "parent" readme below will help you get started with building FPSci from source. The Developer Mode and Path Editor are tools that can be helpful for experiment designers or software developers.
+
+* [Parent readme.md](../readme.md) has many useful links
 * [Developer Mode](./developermode.md)
 * [Path Editor](./patheditor.md)

--- a/docs/userConfigReadme.md
+++ b/docs/userConfigReadme.md
@@ -52,7 +52,7 @@ As an added complexity this sensitivity measure requires the user also report th
 ### Selecting a Reticle
 In order to preview reticles we suggest either:
 
-1. Opening the application with `playMode=False` and using the `Render Controls` menu to setup the correct reticle/crosshair and color/size
+1. Opening the application with `developerMode=true` and using the `Render Controls` menu to setup the correct reticle/crosshair and color/size
 2. Preview the individual images (mostly located in `%g3d%\data10\common\gui\reticle`) to select the desired reticle index (appended to the filename)
 
 If you would not like to have a dynamic reticle (i.e. have it stay the same size/color all the time), then set both values in the array for `reticleScale` and `reticleColor` to the same value.


### PR DESCRIPTION
A variety of documentation fixes related to commits that have previously been merged into master. These include:

- `playMode` -> `developerMode`
- default keymap changes
- `currentUser` moving to `userstatus.Any` #173 #170 
- improved landing page for generated `README.txt` links #172 
- better description of cascading general configs in experiment and session
- various typo corrections