### PR TITLE
Configure results directory path from startup config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ data-files/log.txt
 data-files/*.db
 data-files/*.csv
 data-files/*.pdn
-data-files/result_data
 data-files/*.Any
 data-files/*.jpg
 *.mp4

--- a/docs/startupConfigReadme.md
+++ b/docs/startupConfigReadme.md
@@ -13,6 +13,7 @@ The following fields are valid for a startupconfig.Any file:
 * `windowSize` controls the (default) window size when running in windowed mode (`fullscreen`=`false`) as a `Vector2`. The window can then be resized from this default while running.
 * `experimentConfigPath` sets the path to an [experiment config file](./experimentConfigReadme.md) for futher configuration of an experiment.
 * `userConfigPath` sets the path to a user config file for per user setup.
+* `resultsDirPath` sets the path to the results directory. If this directory does not exists the application will create it at runtime.
 * `audioEnable` turns on or off audio
 
 ## Sample/Default Values

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -21,7 +21,7 @@ public:
 	Vector2 windowSize = { 1920, 980 };			///< Window size (when not run in fullscreen)
     String	experimentConfigPath = "";			///< Optional path to an experiment config file (if "experimentconfig.Any" will not be this file)
     String	userConfigPath = "";				///< Optional path to a user config file (if "userconfig.Any" will not be this file)
-    String	resultsDirPath = "";				///< Optional path to the results directory (defaults to "../results" if empty)
+    String	resultsDirPath = "./results/";		///< Optional path to the results directory
     bool	audioEnable = true;					///< Audio on/off
 
     StartupConfig() {};

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -82,7 +82,7 @@ public:
 	static String formatDirPath(String path) {
 		String fpath = path;
 		// Add a trailing slash to the directory name if missing
-		if (path.substr(path.length() - 1) != "/") {
+		if (!path.empty() && path.substr(path.length() - 1) != "/") {
 			fpath = path + "/";
 		}
 		return fpath;

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -21,7 +21,7 @@ public:
 	Vector2 windowSize = { 1920, 980 };			///< Window size (when not run in fullscreen)
     String	experimentConfigPath = "";			///< Optional path to an experiment config file (if "experimentconfig.Any" will not be this file)
     String	userConfigPath = "";				///< Optional path to a user config file (if "userconfig.Any" will not be this file)
-	String  resultsDirPath = "";					///< Optional path to the results directory (defaults to "../results" if empty)
+	String  resultsDirPath = "";				///< Optional path to the results directory (defaults to "../results" if empty)
 	bool	audioEnable = true;					///< Audio on/off
 
     StartupConfig() {};

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -21,7 +21,8 @@ public:
 	Vector2 windowSize = { 1920, 980 };			///< Window size (when not run in fullscreen)
     String	experimentConfigPath = "";			///< Optional path to an experiment config file (if "experimentconfig.Any" will not be this file)
     String	userConfigPath = "";				///< Optional path to a user config file (if "userconfig.Any" will not be this file)
-    bool	audioEnable = true;					///< Audio on/off
+	String  resultsDirPath = "";					///< Optional path to the results directory (defaults to "../results" if empty)
+	bool	audioEnable = true;					///< Audio on/off
 
     StartupConfig() {};
 
@@ -39,6 +40,8 @@ public:
 			reader.getIfPresent("windowSize", windowSize);
             reader.getIfPresent("experimentConfigPath", experimentConfigPath);
             reader.getIfPresent("userConfigPath", userConfigPath);
+			reader.getIfPresent("resultsDirPath", resultsDirPath);
+			resultsDirPath = formatDirPath(resultsDirPath);
             reader.getIfPresent("audioEnable", audioEnable);
             break;
         default:
@@ -56,6 +59,7 @@ public:
 		if(forceAll || def.fullscreen != fullscreen)						a["fullscreen"] = fullscreen;
         if(forceAll || def.experimentConfigPath != experimentConfigPath)	a["experimentConfigPath"] = experimentConfigPath;
         if(forceAll || def.userConfigPath != userConfigPath)				a["userConfigPath"] = userConfigPath;
+		if(forceAll || def.resultsDirPath != resultsDirPath)				a["resultsPath"] = resultsDirPath;
         if(forceAll || def.audioEnable != audioEnable)						a["audioEnable"] = audioEnable;
         return a;
     }
@@ -73,6 +77,15 @@ public:
     /** filename with given path to user status file */
 	String userStatusConfig() {
 		return userConfigPath + "userstatus.Any";
+	}
+
+	static String formatDirPath(String path) {
+		String fpath = path;
+		// Add a trailing slash to the directory name if missing
+		if (path.substr(path.length() - 1) != "/") {
+			fpath = path + "/";
+		}
+		return fpath;
 	}
 };
 

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -16,9 +16,9 @@ class StartupConfig {
 private:
 public:
     bool	developerMode = false;				///< Sets whether the app is run in "developer mode" (i.e. w/ extra menus)
-    bool	waypointEditorMode = false;			///< Sets whether the app is run w/ the waypoint editor available
-    bool	fullscreen = true;					///< Whether the app runs in windowed mode
-    Vector2 windowSize = { 1920, 980 };			///< Window size (when not run in fullscreen)
+	bool	waypointEditorMode = false;			///< Sets whether the app is run w/ the waypoint editor available
+	bool	fullscreen = true;					///< Whether the app runs in windowed mode
+	Vector2 windowSize = { 1920, 980 };			///< Window size (when not run in fullscreen)
     String	experimentConfigPath = "";			///< Optional path to an experiment config file (if "experimentconfig.Any" will not be this file)
     String	userConfigPath = "";				///< Optional path to a user config file (if "userconfig.Any" will not be this file)
     String	resultsDirPath = "";				///< Optional path to the results directory (defaults to "../results" if empty)

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -16,13 +16,13 @@ class StartupConfig {
 private:
 public:
     bool	developerMode = false;				///< Sets whether the app is run in "developer mode" (i.e. w/ extra menus)
-	bool	waypointEditorMode = false;			///< Sets whether the app is run w/ the waypoint editor available
-	bool	fullscreen = true;					///< Whether the app runs in windowed mode
-	Vector2 windowSize = { 1920, 980 };			///< Window size (when not run in fullscreen)
+    bool	waypointEditorMode = false;			///< Sets whether the app is run w/ the waypoint editor available
+    bool	fullscreen = true;					///< Whether the app runs in windowed mode
+    Vector2 windowSize = { 1920, 980 };			///< Window size (when not run in fullscreen)
     String	experimentConfigPath = "";			///< Optional path to an experiment config file (if "experimentconfig.Any" will not be this file)
     String	userConfigPath = "";				///< Optional path to a user config file (if "userconfig.Any" will not be this file)
-	String  resultsDirPath = "";				///< Optional path to the results directory (defaults to "../results" if empty)
-	bool	audioEnable = true;					///< Audio on/off
+    String	resultsDirPath = "";				///< Optional path to the results directory (defaults to "../results" if empty)
+    bool	audioEnable = true;					///< Audio on/off
 
     StartupConfig() {};
 

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -453,7 +453,9 @@ void FPSciApp::updateSession(const String& id) {
 
 	// Check for need to start latency logging and if so run the logger now
 	const String resultsDir = startupConfig.resultsDirPath.empty() ? "../results/" : startupConfig.resultsDirPath;
-	if (!FileSystem::isDirectory(resultsDir)) { FileSystem::createDirectory(resultsDir); }
+	if (!FileSystem::isDirectory(resultsDir)) {
+		FileSystem::createDirectory(resultsDir); 
+	}
 	const String logName = resultsDir + id + "_" + userStatusTable.currentUser + "_" + String(FPSciLogger::genFileTimestamp());
 	if (latencyLoggerConfig.hasLogger) {
 		if (!sessConfig->clickToPhoton.enabled) {

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -452,7 +452,9 @@ void FPSciApp::updateSession(const String& id) {
 	sess->initialHeadingRadians = player->heading();
 
 	// Check for need to start latency logging and if so run the logger now
-	String logName = "../results/" + id + "_" + userStatusTable.currentUser + "_" + String(FPSciLogger::genFileTimestamp());
+	const String resultsDir = startupConfig.resultsDirPath.empty() ? "../results/" : startupConfig.resultsDirPath;
+	if (!FileSystem::exists(resultsDir)) { FileSystem::createDirectory(resultsDir); }
+	const String logName = resultsDir + id + "_" + userStatusTable.currentUser + "_" + String(FPSciLogger::genFileTimestamp());
 	if (latencyLoggerConfig.hasLogger) {
 		if (!sessConfig->clickToPhoton.enabled) {
 			logPrintf("WARNING: Using a click-to-photon logger without the click-to-photon region enabled!\n\n");

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -452,11 +452,10 @@ void FPSciApp::updateSession(const String& id) {
 	sess->initialHeadingRadians = player->heading();
 
 	// Check for need to start latency logging and if so run the logger now
-	const String resultsDir = startupConfig.resultsDirPath.empty() ? "../results/" : startupConfig.resultsDirPath;
-	if (!FileSystem::isDirectory(resultsDir)) {
-		FileSystem::createDirectory(resultsDir); 
+	if (!FileSystem::isDirectory(startupConfig.resultsDirPath)) {
+		FileSystem::createDirectory(startupConfig.resultsDirPath);
 	}
-	const String logName = resultsDir + id + "_" + userStatusTable.currentUser + "_" + String(FPSciLogger::genFileTimestamp());
+	const String logName = startupConfig.resultsDirPath + id + "_" + userStatusTable.currentUser + "_" + String(FPSciLogger::genFileTimestamp());
 	if (latencyLoggerConfig.hasLogger) {
 		if (!sessConfig->clickToPhoton.enabled) {
 			logPrintf("WARNING: Using a click-to-photon logger without the click-to-photon region enabled!\n\n");

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -453,7 +453,7 @@ void FPSciApp::updateSession(const String& id) {
 
 	// Check for need to start latency logging and if so run the logger now
 	const String resultsDir = startupConfig.resultsDirPath.empty() ? "../results/" : startupConfig.resultsDirPath;
-	if (!FileSystem::exists(resultsDir)) { FileSystem::createDirectory(resultsDir); }
+	if (!FileSystem::isDirectory(resultsDir)) { FileSystem::createDirectory(resultsDir); }
 	const String logName = resultsDir + id + "_" + userStatusTable.currentUser + "_" + String(FPSciLogger::genFileTimestamp());
 	if (latencyLoggerConfig.hasLogger) {
 		if (!sessConfig->clickToPhoton.enabled) {

--- a/source/Logger.cpp
+++ b/source/Logger.cpp
@@ -41,11 +41,6 @@ void FPSciLogger::createResultsFile(const String& filename,
 	const shared_ptr<SessionConfig>& sessConfig, 
 	const String& description)
 {
-	// generate folder result_data if it does not exist.
-	if (!FileSystem::isDirectory(String("../results"))) {
-		FileSystem::createDirectory(String("../results"));
-	}
-
 	// create a unique file name (can bring this back if desired)
 	String timeStr = genUniqueTimestamp();
 


### PR DESCRIPTION
This branch adds support for specifying a `resultsDirPath` in the startup config file to allow the experiment designer to redirect the results directory wherever they would like. It also adds support for creating an arbitrarily named results directory if one does not already exist.

Merging this PR closes #190 
