### PR TITLE
Add support for all config paths in startup config

### DIFF
--- a/data-files/test/startupconfig.Any
+++ b/data-files/test/startupconfig.Any
@@ -1,8 +1,11 @@
 {
-	audioEnable = true;
-	experimentConfigPath = "test/"; 
 	playMode = true;
-	userConfigPath = "test/";
-	windowSize = Vector2(300, 200);
+	audioEnable = true;
+	
 	fullscreen = false;
+	windowSize = Vector2(300, 200);
+	
+	experimentConfigFilename = "test/experimentconfig.any"; 
+	userConfigFilename = "test/userconfig.any";
+	userStatusFilename = "test/userstatus.any";
 }

--- a/docs/startupConfigReadme.md
+++ b/docs/startupConfigReadme.md
@@ -11,10 +11,10 @@ The following fields are valid for a startupconfig.Any file:
 * `waypointEditorMode` controls whether the application is run including additional support for [target path creation/waypoint editing](./patheditor.md). Waypoint editor mode **only applies when `developerMode`=`true`**! In waypoint editor mode an additional menu is made available and the user can drop waypoints or start/stop record their motion using key bound functions.
 * `fullscreen` controls whether the application is run in fullscreen mode or windowed (independent of other options)
 * `windowSize` controls the (default) window size when running in windowed mode (`fullscreen`=`false`) as a `Vector2`. The window can then be resized from this default while running.
-* `experimentConfigFilename` sets the file name and path to an [experiment config file](./experimentConfigReadme.md).
-* `userConfigFilename` sets the file name and path to a [user config file](./userConfigReadme.md).
-* `userStatusFilename` sets the file path to a [user status file](./userStatusReadme.md).
-* `latencyLoggerConfigFilename` sets the file path to a [latency logger config file](systemConfigReadme.md) for controlling latency logger hardware.
+* `experimentConfigFilename` sets the path and file name for an [experiment config file](./experimentConfigReadme.md).
+* `userConfigFilename` sets the path and file name for a [user config file](./userConfigReadme.md).
+* `userStatusFilename` sets the path and file name for a [user status file](./userStatusReadme.md).
+* `latencyLoggerConfigFilename` sets the path and file name for a [latency logger config file](systemConfigReadme.md) for controlling latency logger hardware.
 * `resultsDirPath` sets the path to the results directory. If this directory does not exists the application will create it at runtime.
 * `audioEnable` turns on or off audio
 

--- a/docs/startupConfigReadme.md
+++ b/docs/startupConfigReadme.md
@@ -11,22 +11,22 @@ The following fields are valid for a startupconfig.Any file:
 * `waypointEditorMode` controls whether the application is run including additional support for [target path creation/waypoint editing](./patheditor.md). Waypoint editor mode **only applies when `developerMode`=`true`**! In waypoint editor mode an additional menu is made available and the user can drop waypoints or start/stop record their motion using key bound functions.
 * `fullscreen` controls whether the application is run in fullscreen mode or windowed (independent of other options)
 * `windowSize` controls the (default) window size when running in windowed mode (`fullscreen`=`false`) as a `Vector2`. The window can then be resized from this default while running.
-* `experimentConfigPath` sets the path to an [experiment config file](./experimentConfigReadme.md) for futher configuration of an experiment.
-* `userConfigPath` sets the path to a user config file for per user setup.
-* `userStatusPath` sets the path to a user status file for user tracking.
-* `latencyLoggerConfigPath` sets the path to a latency logger config file for controlling the latency logger hardware.
+* `experimentConfigFilename` sets the file path to an [experiment config file](./experimentConfigReadme.md) for futher configuration of an experiment.
+* `userConfigFilename` sets the file path to a user config file for per user setup.
+* `userStatusFilename` sets the file path to a user status file for user tracking.
+* `latencyLoggerConfigFilename` sets the file path to a latency logger config file for controlling the latency logger hardware.
 * `resultsDirPath` sets the path to the results directory. If this directory does not exists the application will create it at runtime.
 * `audioEnable` turns on or off audio
 
 ## Sample/Default Values
 The default `startup.Any` file is included below (as an example):
 ```
-developerMode = false;            // Set this to true to enable developer mode (extra windows)
-waypointEditorMode = false;       // Set this to true to enable waypoint editor mode (target path creation)
-fullscreen = true;                // Set this to false to run in windowed mode
-windowSize = Vector2(1920, 980);  // This sets the default window size (when running with fullscreen = false)
-experimentConfigPath = "";        // Leave this empty for default "experimentconfig.Any"
-userConfigPath = "";              // Leave this empty for default "userconfig.Any"
-resultsDirPath = "./results/";    // Change to save results somewhere else
-audioEnable = true;               // Set false to turn off audio
+developerMode = false;              // Set this to true to enable developer mode (extra windows)
+waypointEditorMode = false;         // Set this to true to enable waypoint editor mode (target path creation)
+fullscreen = true;                  // Set this to false to run in windowed mode
+windowSize = Vector2(1920, 980);    // This sets the default window size (when running with fullscreen = false)
+experimentConfigFilename = "";      // Leave this empty for default "experimentconfig.Any"
+userConfigFilename = "";            // Leave this empty for default "userconfig.Any"
+resultsDirFilename = "./results/";  // Change to save results somewhere else
+audioEnable = true;                 // Set false to turn off audio
 ```

--- a/docs/startupConfigReadme.md
+++ b/docs/startupConfigReadme.md
@@ -11,22 +11,24 @@ The following fields are valid for a startupconfig.Any file:
 * `waypointEditorMode` controls whether the application is run including additional support for [target path creation/waypoint editing](./patheditor.md). Waypoint editor mode **only applies when `developerMode`=`true`**! In waypoint editor mode an additional menu is made available and the user can drop waypoints or start/stop record their motion using key bound functions.
 * `fullscreen` controls whether the application is run in fullscreen mode or windowed (independent of other options)
 * `windowSize` controls the (default) window size when running in windowed mode (`fullscreen`=`false`) as a `Vector2`. The window can then be resized from this default while running.
-* `experimentConfigFilename` sets the file path to an [experiment config file](./experimentConfigReadme.md) for futher configuration of an experiment.
-* `userConfigFilename` sets the file path to a user config file for per user setup.
-* `userStatusFilename` sets the file path to a user status file for user tracking.
-* `latencyLoggerConfigFilename` sets the file path to a latency logger config file for controlling the latency logger hardware.
+* `experimentConfigFilename` sets the file name and path to an [experiment config file](./experimentConfigReadme.md).
+* `userConfigFilename` sets the file name and path to a [user config file](./userConfigReadme.md).
+* `userStatusFilename` sets the file path to a [user status file](./userStatusReadme.md).
+* `latencyLoggerConfigFilename` sets the file path to a [latency logger config file](systemConfigReadme.md) for controlling latency logger hardware.
 * `resultsDirPath` sets the path to the results directory. If this directory does not exists the application will create it at runtime.
 * `audioEnable` turns on or off audio
 
 ## Sample/Default Values
 The default `startup.Any` file is included below (as an example):
 ```
-developerMode = false;              // Set this to true to enable developer mode (extra windows)
-waypointEditorMode = false;         // Set this to true to enable waypoint editor mode (target path creation)
-fullscreen = true;                  // Set this to false to run in windowed mode
-windowSize = Vector2(1920, 980);    // This sets the default window size (when running with fullscreen = false)
-experimentConfigFilename = "";      // Leave this empty for default "experimentconfig.Any"
-userConfigFilename = "";            // Leave this empty for default "userconfig.Any"
-resultsDirPath = "./results/";      // Change to save results somewhere else
-audioEnable = true;                 // Set false to turn off audio
+developerMode = false;                              // Set this to true to enable developer mode (extra windows)
+waypointEditorMode = false;                         // Set this to true to enable waypoint editor mode (target path creation)
+fullscreen = true;                                  // Set this to false to run in windowed mode
+windowSize = Vector2(1920, 980);                    // This sets the default window size (when running with fullscreen = false)
+experimentConfigFilename = "experimentconfig.Any";  // Can include a path
+userConfigFilename = "userconfig.Any";              // Can include a path
+userStatusFilename = "userstatus.Any";              // Can include a path
+latencyLoggerConfigFilename = "systemconfig.Any";   // Can include a path
+resultsDirPath = "./results/";                      // Change to save results somewhere else
+audioEnable = true;                                 // Set false to turn off audio
 ```

--- a/docs/startupConfigReadme.md
+++ b/docs/startupConfigReadme.md
@@ -27,6 +27,6 @@ fullscreen = true;                  // Set this to false to run in windowed mode
 windowSize = Vector2(1920, 980);    // This sets the default window size (when running with fullscreen = false)
 experimentConfigFilename = "";      // Leave this empty for default "experimentconfig.Any"
 userConfigFilename = "";            // Leave this empty for default "userconfig.Any"
-resultsDirFilename = "./results/";  // Change to save results somewhere else
+resultsDirPath = "./results/";      // Change to save results somewhere else
 audioEnable = true;                 // Set false to turn off audio
 ```

--- a/docs/startupConfigReadme.md
+++ b/docs/startupConfigReadme.md
@@ -13,6 +13,8 @@ The following fields are valid for a startupconfig.Any file:
 * `windowSize` controls the (default) window size when running in windowed mode (`fullscreen`=`false`) as a `Vector2`. The window can then be resized from this default while running.
 * `experimentConfigPath` sets the path to an [experiment config file](./experimentConfigReadme.md) for futher configuration of an experiment.
 * `userConfigPath` sets the path to a user config file for per user setup.
+* `userStatusPath` sets the path to a user status file for user tracking.
+* `latencyLoggerConfigPath` sets the path to a latency logger config file for controlling the latency logger hardware.
 * `audioEnable` turns on or off audio
 
 ## Sample/Default Values

--- a/docs/startupConfigReadme.md
+++ b/docs/startupConfigReadme.md
@@ -14,6 +14,7 @@ The following fields are valid for a startupconfig.Any file:
 * `experimentConfigFilename` sets the path and file name for an [experiment config file](./experimentConfigReadme.md).
 * `userConfigFilename` sets the path and file name for a [user config file](./userConfigReadme.md).
 * `userStatusFilename` sets the path and file name for a [user status file](./userStatusReadme.md).
+* `keymapConfigFilename` sets the path and file name for a [keymap config file](./keymap.md).
 * `latencyLoggerConfigFilename` sets the path and file name for a [latency logger config file](systemConfigReadme.md) for controlling latency logger hardware.
 * `resultsDirPath` sets the path to the results directory. If this directory does not exists the application will create it at runtime.
 * `audioEnable` turns on or off audio
@@ -28,6 +29,7 @@ windowSize = Vector2(1920, 980);                    // This sets the default win
 experimentConfigFilename = "experimentconfig.Any";  // Can include a path
 userConfigFilename = "userconfig.Any";              // Can include a path
 userStatusFilename = "userstatus.Any";              // Can include a path
+keymapConfigFilename = "keymap.Any";                // Can include a path
 latencyLoggerConfigFilename = "systemconfig.Any";   // Can include a path
 resultsDirPath = "./results/";                      // Change to save results somewhere else
 audioEnable = true;                                 // Set false to turn off audio

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -142,7 +142,7 @@ public:
 		return a;
 	}
 
-	static KeyMapping load(String filename) {
+	static KeyMapping load(const String& filename) {
 		if (!FileSystem::exists(System::findDataFile(filename, false))) {
 			KeyMapping mapping = KeyMapping();
 			mapping.toAny().save(filename);
@@ -322,7 +322,7 @@ public:
 		if (!FileSystem::exists(filename)) { 
 			return LatencyLoggerConfig();		// Create the default
 		}
-		return Any::fromFile(System::findDataFile("systemconfig.Any"));
+		return Any::fromFile(System::findDataFile(filename));
 	}
 
 	/** Print the latency logger config to log.txt */
@@ -576,19 +576,19 @@ public:
 
 	/** Get the user status table from file */
 	static UserStatusTable load(const String& filename) {
-		if (!FileSystem::exists(filename)) { // if file not found, create a default userstatus.Any
-			UserStatusTable defaultStatus = UserStatusTable();			// Create empty status
+		if (!FileSystem::exists(filename)) {						// if file not found, create a default
+			UserStatusTable defaultStatus = UserStatusTable();		// Create empty status
 			UserSessionStatus user;
 			user.sessionOrder = Array<String> ({ "60Hz", "30Hz" });	// Add "default" sessions we add to
-			defaultStatus.userInfo.append(user);						// Add single "default" user
-			defaultStatus.currentUser = user.id;						// Set "default" user as current user
-			defaultStatus.save(filename);								// Save .any file
+			defaultStatus.userInfo.append(user);					// Add single "default" user
+			defaultStatus.currentUser = user.id;					// Set "default" user as current user
+			defaultStatus.save(filename);							// Save .any file
 			return defaultStatus;
 		}
 		return Any::fromFile(System::findDataFile(filename));
 	}
 
-	inline void save(const String& filename = "userstatus.Any") { toAny().save(filename);  }
+	inline void save(const String& filename) { toAny().save(filename);  }
 
 	/** Get a given user's status from the table by ID */
 	shared_ptr<UserSessionStatus> getUserStatus(String id) {

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -644,7 +644,7 @@ public:
 		for(String defSessId : defaultSessionOrder) {
 			noSessions = false;
 			if (!sessions.contains(defSessId)) {
-				throw format("Default session config in user status has session with ID: \"%s\". This session ID does not appear in experimentconfig.Any's \"sessions\" array. Valid options are: %s", defSessId, expSessions);
+				throw format("Default session config in user status has session with ID: \"%s\". This session ID does not appear in the experiment config file's \"sessions\" array. Valid options are: %s", defSessId, expSessions);
 			}
 		}
 
@@ -656,14 +656,14 @@ public:
 			for (String userSessId : userStatus.sessionOrder) {
 				noSessions = false;
 				if (!sessions.contains(userSessId)) {
-					throw format("User \"%s\" has session with ID: \"%s\" in their User Status \"sessions\" Array. This session ID does not appear in the experimentconfig.Any \"sessions\" array. Valid options are: %s", userStatus.id, userSessId, expSessions);
+					throw format("User \"%s\" has session with ID: \"%s\" in their User Status \"sessions\" Array. This session ID does not appear in the experiment config file's \"sessions\" array. Valid options are: %s", userStatus.id, userSessId, expSessions);
 				}
 			}
 		}
 
 		// Check current user has a valid config
 		if (currentUser.empty()) {
-			throw "\"currentUser\" field is not specified in the user status file!\nIf you are migrating from an older version of FPSci, please cut the \"currentUser = ...\" line\nfrom userconfig.Any and paste it in userstatus.Any.";
+			throw "\"currentUser\" field is not specified in the user status file!\nIf you are migrating from an older version of FPSci, please cut the \"currentUser = ...\" line\nfrom the user config file and paste it in the user status file.";
 		}
 		else if (!users.contains(currentUser)) {
 			throw format("Current user \"%s\" does not have a valid entry in the user config file!", currentUser);
@@ -671,7 +671,7 @@ public:
 
 		// Check if no default/per user sessions are present
 		if (noSessions) { 
-			throw "Found no sessions in the userstatus.Any file!"; 
+			throw "Found no sessions in the user status file!"; 
 		}
 	}
 

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -22,6 +22,7 @@ public:
     String	experimentConfigFilename = "experimentconfig.Any";	///< Optional path to an experiment config file
     String	userConfigFilename = "userconfig.Any";				///< Optional path to a user config file
 	String  userStatusFilename = "userstatus.Any";				///< Optional path to a user status file
+	String  keymapConfigFilename = "keymap.Any";				///< Optional path to a keymap config file
 	String  latencyLoggerConfigFilename = "systemconfig.Any";	///< Optional path to a latency logger config file
     String	resultsDirPath = "./results/";						///< Optional path to the results directory
 	bool	audioEnable = true;									///< Audio on/off
@@ -45,6 +46,8 @@ public:
 			checkValidAnyFilename("userConfigFilename", userConfigFilename);
 			reader.getIfPresent("userStatusFilename", userStatusFilename);
 			checkValidAnyFilename("userStatusFilename", userStatusFilename);
+			reader.getIfPresent("keymapConfigFilename", keymapConfigFilename);
+			checkValidAnyFilename("keymapConfigFilename", keymapConfigFilename);
 			reader.getIfPresent("latencyLoggerConfigFilename", latencyLoggerConfigFilename);
 			checkValidAnyFilename("latencyLoggerConfigFilename", latencyLoggerConfigFilename);
 			reader.getIfPresent("resultsDirPath", resultsDirPath);
@@ -67,6 +70,7 @@ public:
         if(forceAll || def.experimentConfigFilename != experimentConfigFilename)		a["experimentConfigFilename"] = experimentConfigFilename;
         if(forceAll || def.userConfigFilename != userConfigFilename)					a["userConfigFilename"] = userConfigFilename;
 		if(forceAll || def.userStatusFilename != userStatusFilename)					a["userStatusFilename"] = userStatusFilename;
+		if(forceAll || def.keymapConfigFilename != keymapConfigFilename)				a["keymapConfigFilename"] = keymapConfigFilename;
 		if(forceAll || def.latencyLoggerConfigFilename != latencyLoggerConfigFilename)	a["latencyLoggerConfigFilename"] = latencyLoggerConfigFilename;
 		if(forceAll || def.resultsDirPath != resultsDirPath)							a["resultsDirPath"] = resultsDirPath;
         if(forceAll || def.audioEnable != audioEnable)									a["audioEnable"] = audioEnable;
@@ -138,10 +142,10 @@ public:
 		return a;
 	}
 
-	static KeyMapping load(String filename = "keymap.Any") {
+	static KeyMapping load(String filename) {
 		if (!FileSystem::exists(System::findDataFile(filename, false))) {
 			KeyMapping mapping = KeyMapping();
-			mapping.toAny().save("keymap.Any");
+			mapping.toAny().save(filename);
 			return mapping;
 		}
 		return Any::fromFile(System::findDataFile(filename));

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -19,10 +19,10 @@ public:
 	bool	waypointEditorMode = false;			///< Sets whether the app is run w/ the waypoint editor available
 	bool	fullscreen = true;					///< Whether the app runs in windowed mode
 	Vector2 windowSize = { 1920, 980 };			///< Window size (when not run in fullscreen)
-    String	experimentConfigPath;				///< Optional path to an experiment config file (if empty assumes "./experimentconfig.Any" will be this file)
-    String	userConfigPath;						///< Optional path to a user config file (if empty assumes "./userconfig.Any" will be this file)
-	String  userStatusPath;						///< Optional path to a user status file (if empty assumes "./userstatus.Any" will be this file)
-	String  latencyLoggerConfigPath;			///< Optional path to a latency logger config file (if empty assumes "./systemconfig.Any" will be this file)
+    String	experimentConfigFilename;			///< Optional path to an experiment config file (if empty assumes "./experimentconfig.Any" will be this file)
+    String	userConfigFilename;					///< Optional path to a user config file (if empty assumes "./userconfig.Any" will be this file)
+	String  userStatusFilename;					///< Optional path to a user status file (if empty assumes "./userstatus.Any" will be this file)
+	String  latencyLoggerConfigFilename;		///< Optional path to a latency logger config file (if empty assumes "./systemconfig.Any" will be this file)
     String	resultsDirPath = "./results/";		///< Optional path to the results directory
 	bool	audioEnable = true;					///< Audio on/off
     StartupConfig() {};
@@ -39,14 +39,14 @@ public:
 			reader.getIfPresent("waypointEditorMode", waypointEditorMode);
 			reader.getIfPresent("fullscreen", fullscreen);
 			reader.getIfPresent("windowSize", windowSize);
-            reader.getIfPresent("experimentConfigPath", experimentConfigPath);
-            reader.getIfPresent("userConfigPath", userConfigPath);
-			reader.getIfPresent("userStatusPath", userStatusPath);
-			reader.getIfPresent("latencyLoggerConfigPath", latencyLoggerConfigPath);
-			checkValidAnyPath(experimentConfigPath);
-			checkValidAnyPath(userConfigPath);
-			checkValidAnyPath(userStatusPath);
-			checkValidAnyPath(latencyLoggerConfigPath);
+            reader.getIfPresent("experimentConfigFilename", experimentConfigFilename);
+            reader.getIfPresent("userConfigFilename", userConfigFilename);
+			reader.getIfPresent("userStatusFilename", userStatusFilename);
+			reader.getIfPresent("latencyLoggerConfigFilename", latencyLoggerConfigFilename);
+			checkValidAnyFilename(experimentConfigFilename);
+			checkValidAnyFilename(userConfigFilename);
+			checkValidAnyFilename(userStatusFilename);
+			checkValidAnyFilename(latencyLoggerConfigFilename);
 			reader.getIfPresent("resultsDirPath", resultsDirPath);
 			resultsDirPath = formatDirPath(resultsDirPath);
             reader.getIfPresent("audioEnable", audioEnable);
@@ -64,28 +64,28 @@ public:
         if(forceAll || def.developerMode != developerMode)					a["developerMode"] = developerMode;
 		if(forceAll || def.waypointEditorMode != waypointEditorMode)		a["waypointEditorMode"] = waypointEditorMode;
 		if(forceAll || def.fullscreen != fullscreen)						a["fullscreen"] = fullscreen;
-        if(forceAll || def.experimentConfigPath != experimentConfigPath)	a["experimentConfigPath"] = experimentConfigPath;
-        if(forceAll || def.userConfigPath != userConfigPath)				a["userConfigPath"] = userConfigPath;
-		if(forceAll || def.userStatusPath != userStatusPath)				a["userStatusPath"] = userStatusPath;
-		if(forceAll || def.latencyLoggerConfigPath != latencyLoggerConfigPath) a["latencyLoggerConfigPath"] = latencyLoggerConfigPath;
+        if(forceAll || def.experimentConfigFilename != experimentConfigFilename)	a["experimentConfigPath"] = experimentConfigFilename;
+        if(forceAll || def.userConfigFilename != userConfigFilename)				a["userConfigPath"] = userConfigFilename;
+		if(forceAll || def.userStatusFilename != userStatusFilename)				a["userStatusPath"] = userStatusFilename;
+		if(forceAll || def.latencyLoggerConfigFilename != latencyLoggerConfigFilename) a["latencyLoggerConfigPath"] = latencyLoggerConfigFilename;
 		if(forceAll || def.resultsDirPath != resultsDirPath)				a["resultsDirPath"] = resultsDirPath;
         if(forceAll || def.audioEnable != audioEnable)						a["audioEnable"] = audioEnable;
         return a;
     }
 
     /** full path (including filename) to experiment config file */
-    inline const String experimentConfig() { return experimentConfigPath.empty() ? "experimentconfig.Any" : experimentConfigPath; }
+    inline const String experimentConfig() { return experimentConfigFilename.empty() ? "experimentconfig.Any" : experimentConfigFilename; }
 
     /** full path (including filename) to user config file */
-	inline const String userConfig() { return userConfigPath.empty() ? "userconfig.Any" : userConfigPath; }
+	inline const String userConfig() { return userConfigFilename.empty() ? "userconfig.Any" : userConfigFilename; }
 	
     /** full path (including filename) to user status file */
-	inline const String userStatusConfig() { return userStatusPath.empty() ? "userstatus.Any" : userStatusPath; }
+	inline const String userStatusConfig() { return userStatusFilename.empty() ? "userstatus.Any" : userStatusFilename; }
 
 	/** full path (including filename) to latency logger config file */
-	inline const String latencyLoggerConfig() { return latencyLoggerConfigPath.empty() ? "systemconfig.Any" : latencyLoggerConfigPath; }
+	inline const String latencyLoggerConfig() { return latencyLoggerConfigFilename.empty() ? "systemconfig.Any" : latencyLoggerConfigFilename; }
 
-	static void checkValidAnyPath(String path) {
+	static void checkValidAnyFilename(String path) {
 		if (path.empty()) return;		// Allow empty values since these are the defaults
 		// Check for non empty paths having ".any" file extension
 		alwaysAssertM(toLower(path.substr(path.length() - 4)) == ".any",

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -67,6 +67,7 @@ public:
         if(forceAll || def.experimentConfigPath != experimentConfigPath)	a["experimentConfigPath"] = experimentConfigPath;
         if(forceAll || def.userConfigPath != userConfigPath)				a["userConfigPath"] = userConfigPath;
 		if(forceAll || def.userStatusPath != userStatusPath)				a["userStatusPath"] = userStatusPath;
+		if(forceAll || def.latencyLoggerConfigPath != latencyLoggerConfigPath) a["latencyLoggerConfigPath"] = latencyLoggerConfigPath;
 		if(forceAll || def.resultsDirPath != resultsDirPath)				a["resultsDirPath"] = resultsDirPath;
         if(forceAll || def.audioEnable != audioEnable)						a["audioEnable"] = audioEnable;
         return a;

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -2001,7 +2001,7 @@ public:
         // if file not found, build a default
         if (!FileSystem::exists(System::findDataFile(filename, false))) {
             ExperimentConfig ex = ExperimentConfig();
-			ex.toAny().save("experimentconfig.Any");
+			ex.toAny().save(filename);
 			SessionConfig::defaultConfig = (FpsConfig)ex;
 			return ex;
 		}

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -40,13 +40,13 @@ public:
 			reader.getIfPresent("fullscreen", fullscreen);
 			reader.getIfPresent("windowSize", windowSize);
             reader.getIfPresent("experimentConfigFilename", experimentConfigFilename);
+			checkValidAnyFilename("experimentConfigFilename", experimentConfigFilename);
             reader.getIfPresent("userConfigFilename", userConfigFilename);
+			checkValidAnyFilename("userConfigFilename", userConfigFilename);
 			reader.getIfPresent("userStatusFilename", userStatusFilename);
+			checkValidAnyFilename("userStatusFilename", userStatusFilename);
 			reader.getIfPresent("latencyLoggerConfigFilename", latencyLoggerConfigFilename);
-			checkValidAnyFilename(experimentConfigFilename);
-			checkValidAnyFilename(userConfigFilename);
-			checkValidAnyFilename(userStatusFilename);
-			checkValidAnyFilename(latencyLoggerConfigFilename);
+			checkValidAnyFilename("latencyLoggerConfigFilename", latencyLoggerConfigFilename);
 			reader.getIfPresent("resultsDirPath", resultsDirPath);
 			resultsDirPath = formatDirPath(resultsDirPath);
             reader.getIfPresent("audioEnable", audioEnable);
@@ -73,10 +73,9 @@ public:
         return a;
     }
 
-	/** Assert that the filename ends in .any */
-	static void checkValidAnyFilename(const String& path) {
-		alwaysAssertM(toLower(path.substr(path.length() - 4)) == ".any",
-			format("All config filenames specified in the startup config must end with \".any\"!, check path: \"%s\"!", path));
+	/** Assert that the filename `path` ends in .any and report `errorName` if it doesn't */
+	static void checkValidAnyFilename(const String& errorName, const String& path) {
+		alwaysAssertM(toLower(path.substr(path.length() - 4)) == ".any", "Config filenames specified in the startup config must end with \".any\"!, check the " + errorName + "!\n");
 	}
 
 	/** Returns the provided path with trailing slashes added if missing */

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -22,7 +22,7 @@ public:
     String	experimentConfigFilename;			///< Optional path to an experiment config file (if empty assumes "./experimentconfig.Any" will be this file)
     String	userConfigFilename;					///< Optional path to a user config file (if empty assumes "./userconfig.Any" will be this file)
 	String  userStatusFilename;					///< Optional path to a user status file (if empty assumes "./userstatus.Any" will be this file)
-	String  latencyLoggerConfigFilename;		///< Optional path to a latency logger config file (if empty assumes "./systemconfig.Any" will be this file)
+	String  latencyLoggerConfigFilename = "systemconfig.Any";		///< Optional path to a latency logger config file
     String	resultsDirPath = "./results/";		///< Optional path to the results directory
 	bool	audioEnable = true;					///< Audio on/off
     StartupConfig() {};
@@ -64,10 +64,10 @@ public:
         if(forceAll || def.developerMode != developerMode)					a["developerMode"] = developerMode;
 		if(forceAll || def.waypointEditorMode != waypointEditorMode)		a["waypointEditorMode"] = waypointEditorMode;
 		if(forceAll || def.fullscreen != fullscreen)						a["fullscreen"] = fullscreen;
-        if(forceAll || def.experimentConfigFilename != experimentConfigFilename)	a["experimentConfigPath"] = experimentConfigFilename;
-        if(forceAll || def.userConfigFilename != userConfigFilename)				a["userConfigPath"] = userConfigFilename;
-		if(forceAll || def.userStatusFilename != userStatusFilename)				a["userStatusPath"] = userStatusFilename;
-		if(forceAll || def.latencyLoggerConfigFilename != latencyLoggerConfigFilename) a["latencyLoggerConfigPath"] = latencyLoggerConfigFilename;
+        if(forceAll || def.experimentConfigFilename != experimentConfigFilename)	a["experimentConfigFilename"] = experimentConfigFilename;
+        if(forceAll || def.userConfigFilename != userConfigFilename)				a["userConfigFilename"] = userConfigFilename;
+		if(forceAll || def.userStatusFilename != userStatusFilename)				a["userStatusFilename"] = userStatusFilename;
+		if(forceAll || def.latencyLoggerConfigFilename != latencyLoggerConfigFilename) a["latencyLoggerConfigFilename"] = latencyLoggerConfigFilename;
 		if(forceAll || def.resultsDirPath != resultsDirPath)				a["resultsDirPath"] = resultsDirPath;
         if(forceAll || def.audioEnable != audioEnable)						a["audioEnable"] = audioEnable;
         return a;
@@ -81,9 +81,6 @@ public:
 	
     /** full path (including filename) to user status file */
 	inline const String userStatusConfig() { return userStatusFilename.empty() ? "userstatus.Any" : userStatusFilename; }
-
-	/** full path (including filename) to latency logger config file */
-	inline const String latencyLoggerConfig() { return latencyLoggerConfigFilename.empty() ? "systemconfig.Any" : latencyLoggerConfigFilename; }
 
 	static void checkValidAnyFilename(String path) {
 		if (path.empty()) return;		// Allow empty values since these are the defaults

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -79,9 +79,9 @@ public:
 			format("All config filenames specified in the startup config must end with \".any\"!, check path: \"%s\"!", path));
 	}
 
+	/** Returns the provided path with trailing slashes added if missing */
 	static String formatDirPath(const String& path) {
 		String fpath = path;
-		// Add a trailing slash to the directory name if missing
 		if (!path.empty() && path.substr(path.length() - 1) != "/") {
 			fpath = path + "/";
 		}

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -15,16 +15,16 @@ static bool operator!=(Array<T> a1, Array<T> a2) {
 class StartupConfig {
 private:
 public:
-    bool	developerMode = false;				///< Sets whether the app is run in "developer mode" (i.e. w/ extra menus)
-	bool	waypointEditorMode = false;			///< Sets whether the app is run w/ the waypoint editor available
-	bool	fullscreen = true;					///< Whether the app runs in windowed mode
-	Vector2 windowSize = { 1920, 980 };			///< Window size (when not run in fullscreen)
-    String	experimentConfigFilename;			///< Optional path to an experiment config file (if empty assumes "./experimentconfig.Any" will be this file)
-    String	userConfigFilename;					///< Optional path to a user config file (if empty assumes "./userconfig.Any" will be this file)
-	String  userStatusFilename;					///< Optional path to a user status file (if empty assumes "./userstatus.Any" will be this file)
-	String  latencyLoggerConfigFilename = "systemconfig.Any";		///< Optional path to a latency logger config file
-    String	resultsDirPath = "./results/";		///< Optional path to the results directory
-	bool	audioEnable = true;					///< Audio on/off
+    bool	developerMode = false;								///< Sets whether the app is run in "developer mode" (i.e. w/ extra menus)
+	bool	waypointEditorMode = false;							///< Sets whether the app is run w/ the waypoint editor available
+	bool	fullscreen = true;									///< Whether the app runs in windowed mode
+	Vector2 windowSize = { 1920, 980 };							///< Window size (when not run in fullscreen)
+    String	experimentConfigFilename = "experimentconfig.Any";	///< Optional path to an experiment config file
+    String	userConfigFilename = "userconfig.Any";				///< Optional path to a user config file
+	String  userStatusFilename = "userstatus.Any";				///< Optional path to a user status file
+	String  latencyLoggerConfigFilename = "systemconfig.Any";	///< Optional path to a latency logger config file
+    String	resultsDirPath = "./results/";						///< Optional path to the results directory
+	bool	audioEnable = true;									///< Audio on/off
     StartupConfig() {};
 
 	/** Construct from any here */
@@ -61,35 +61,25 @@ public:
     Any toAny(const bool forceAll = true) const {
 		StartupConfig def;		// Create a dummy default config for value testing
         Any a(Any::TABLE);
-        if(forceAll || def.developerMode != developerMode)					a["developerMode"] = developerMode;
-		if(forceAll || def.waypointEditorMode != waypointEditorMode)		a["waypointEditorMode"] = waypointEditorMode;
-		if(forceAll || def.fullscreen != fullscreen)						a["fullscreen"] = fullscreen;
-        if(forceAll || def.experimentConfigFilename != experimentConfigFilename)	a["experimentConfigFilename"] = experimentConfigFilename;
-        if(forceAll || def.userConfigFilename != userConfigFilename)				a["userConfigFilename"] = userConfigFilename;
-		if(forceAll || def.userStatusFilename != userStatusFilename)				a["userStatusFilename"] = userStatusFilename;
-		if(forceAll || def.latencyLoggerConfigFilename != latencyLoggerConfigFilename) a["latencyLoggerConfigFilename"] = latencyLoggerConfigFilename;
-		if(forceAll || def.resultsDirPath != resultsDirPath)				a["resultsDirPath"] = resultsDirPath;
-        if(forceAll || def.audioEnable != audioEnable)						a["audioEnable"] = audioEnable;
+        if(forceAll || def.developerMode != developerMode)								a["developerMode"] = developerMode;
+		if(forceAll || def.waypointEditorMode != waypointEditorMode)					a["waypointEditorMode"] = waypointEditorMode;
+		if(forceAll || def.fullscreen != fullscreen)									a["fullscreen"] = fullscreen;
+        if(forceAll || def.experimentConfigFilename != experimentConfigFilename)		a["experimentConfigFilename"] = experimentConfigFilename;
+        if(forceAll || def.userConfigFilename != userConfigFilename)					a["userConfigFilename"] = userConfigFilename;
+		if(forceAll || def.userStatusFilename != userStatusFilename)					a["userStatusFilename"] = userStatusFilename;
+		if(forceAll || def.latencyLoggerConfigFilename != latencyLoggerConfigFilename)	a["latencyLoggerConfigFilename"] = latencyLoggerConfigFilename;
+		if(forceAll || def.resultsDirPath != resultsDirPath)							a["resultsDirPath"] = resultsDirPath;
+        if(forceAll || def.audioEnable != audioEnable)									a["audioEnable"] = audioEnable;
         return a;
     }
 
-    /** full path (including filename) to experiment config file */
-    inline const String experimentConfig() { return experimentConfigFilename.empty() ? "experimentconfig.Any" : experimentConfigFilename; }
-
-    /** full path (including filename) to user config file */
-	inline const String userConfig() { return userConfigFilename.empty() ? "userconfig.Any" : userConfigFilename; }
-	
-    /** full path (including filename) to user status file */
-	inline const String userStatusConfig() { return userStatusFilename.empty() ? "userstatus.Any" : userStatusFilename; }
-
-	static void checkValidAnyFilename(String path) {
-		if (path.empty()) return;		// Allow empty values since these are the defaults
-		// Check for non empty paths having ".any" file extension
+	/** Assert that the filename ends in .any */
+	static void checkValidAnyFilename(const String& path) {
 		alwaysAssertM(toLower(path.substr(path.length() - 4)) == ".any",
-			format("All config files specified in the startup config must end with \".any\"!, check path: \"%s\"!", path));
+			format("All config filenames specified in the startup config must end with \".any\"!, check path: \"%s\"!", path));
 	}
 
-	static String formatDirPath(String path) {
+	static String formatDirPath(const String& path) {
 		String fpath = path;
 		// Add a trailing slash to the directory name if missing
 		if (!path.empty() && path.substr(path.length() - 1) != "/") {
@@ -324,7 +314,7 @@ public:
 	}
 
 	/** Load a latency logger config from file */
-	static LatencyLoggerConfig load(String filename) {
+	static LatencyLoggerConfig load(const String& filename) {
 		// if file not found, create a default latency logger config
 		if (!FileSystem::exists(filename)) { 
 			return LatencyLoggerConfig();		// Create the default
@@ -451,7 +441,7 @@ public:
 	}
 
 	/** Simple rotine to get the UserTable Any structure from file */
-	static UserTable load(String filename) {
+	static UserTable load(const String& filename) {
 		// Create default UserConfig file
 		if (!FileSystem::exists(System::findDataFile(filename, false))) { // if file not found, generate a default user config table
 			UserTable defTable = UserTable();
@@ -462,7 +452,7 @@ public:
 		return Any::fromFile(System::findDataFile(filename));
 	}
 
-	inline void save(String filename) { toAny().save(filename); }
+	inline void save(const String& filename) { toAny().save(filename); }
 
 	/** Get an array of user IDs */
 	Array<String> getIds() {
@@ -582,20 +572,20 @@ public:
 	}
 
 	/** Get the user status table from file */
-	static UserStatusTable load(String filename) {
+	static UserStatusTable load(const String& filename) {
 		if (!FileSystem::exists(filename)) { // if file not found, create a default userstatus.Any
-			UserStatusTable defStatus = UserStatusTable();			// Create empty status
+			UserStatusTable defaultStatus = UserStatusTable();			// Create empty status
 			UserSessionStatus user;
 			user.sessionOrder = Array<String> ({ "60Hz", "30Hz" });	// Add "default" sessions we add to
-			defStatus.userInfo.append(user);						// Add single "default" user
-			defStatus.currentUser = user.id;						// Set "default" user as current user
-			defStatus.save(filename);								// Save .any file
-			return defStatus;
+			defaultStatus.userInfo.append(user);						// Add single "default" user
+			defaultStatus.currentUser = user.id;						// Set "default" user as current user
+			defaultStatus.save(filename);								// Save .any file
+			return defaultStatus;
 		}
 		return Any::fromFile(System::findDataFile(filename));
 	}
 
-	inline void save(String filename = "userstatus.Any") { toAny().save(filename);  }
+	inline void save(const String& filename = "userstatus.Any") { toAny().save(filename);  }
 
 	/** Get a given user's status from the table by ID */
 	shared_ptr<UserSessionStatus> getUserStatus(String id) {
@@ -2008,7 +1998,7 @@ public:
 	}
 
 	/** Get the experiment config from file */
-	static ExperimentConfig load(String filename) {
+	static ExperimentConfig load(const String& filename) {
         // if file not found, build a default
         if (!FileSystem::exists(System::findDataFile(filename, false))) {
             ExperimentConfig ex = ExperimentConfig();

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -53,7 +53,7 @@ void FPSciApp::onInit() {
 	displayRes = OSWindow::primaryDisplaySize();						
 
 	// Load the key binds
-	keyMap = KeyMapping::load();
+	keyMap = KeyMapping::load(startupConfig.keymapConfigFilename);
 	userInput->setKeyMapping(&keyMap.uiMap);
 
 	// Setup/update waypoint manager

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -46,7 +46,7 @@ void FPSciApp::onInit() {
 	info.printToLog();										// Print system info to log.txt
 
 	// Get and save system configuration
-	latencyLoggerConfig = LatencyLoggerConfig::load(startupConfig.latencyLoggerConfig());
+	latencyLoggerConfig = LatencyLoggerConfig::load(startupConfig.latencyLoggerConfigFilename);
 	latencyLoggerConfig.printToLog();						// Print the latency logger config to log.txt								
 
 	// Get the size of the primary display

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -46,7 +46,7 @@ void FPSciApp::onInit() {
 	info.printToLog();										// Print system info to log.txt
 
 	// Get and save system configuration
-	latencyLoggerConfig = LatencyLoggerConfig::load();
+	latencyLoggerConfig = LatencyLoggerConfig::load(startupConfig.latencyLoggerConfig());
 	latencyLoggerConfig.printToLog();						// Print the latency logger config to log.txt								
 
 	// Get the size of the primary display

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -26,18 +26,18 @@ void FPSciApp::onInit() {
 	GApp::onInit();
 
 	// Load experiment setting from file
-	experimentConfig = ExperimentConfig::load(startupConfig.experimentConfig());
+	experimentConfig = ExperimentConfig::load(startupConfig.experimentConfigFilename);
 	experimentConfig.printToLog();
 
 	Array<String> sessionIds;
 	experimentConfig.getSessionIds(sessionIds);
 
 	// Load per user settings from file
-	userTable = UserTable::load(startupConfig.userConfig());
+	userTable = UserTable::load(startupConfig.userConfigFilename);
 	userTable.printToLog();
 
 	// Load per experiment user settings from file and make sure they are valid
-	userStatusTable = UserStatusTable::load(startupConfig.userStatusConfig());
+	userStatusTable = UserStatusTable::load(startupConfig.userStatusFilename);
 	userStatusTable.printToLog();
 	userStatusTable.validate(sessionIds, userTable.getIds());
 	

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -167,11 +167,11 @@ public:
 
     /** callbacks for saving user status and config */
 	void saveUserConfig(void) {
-		userTable.save(startupConfig.userConfig());
+		userTable.save(startupConfig.userConfigFilename);
 		logPrintf("User table saved.\n");			// Print message to log
 	}
 	void saveUserStatus(void) { 
-		userStatusTable.save(startupConfig.userStatusConfig()); 
+		userStatusTable.save(startupConfig.userStatusFilename); 
 		logPrintf("User status saved.\n");
 	}
 


### PR DESCRIPTION
This branch adds support for specifying the user status as well as the latency logger config (via their full file paths) in the startup config file.

Merging this PR closes #194.