### PR TITLE
Target previews

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -344,7 +344,8 @@ These flags help control the behavior of click-to-photon monitoring in applicati
 |`showReferenceTarget`   |`bool`                | Show a reference target to re-center the view between trials/sessions?             |
 |`referenceTargetColor` |`Color3`               | The color of the "reference" targets spawned between trials                        |
 |`referenceTargetSize`  |m                      | The size of the "reference" targets spawned between trials                         |
-
+|`showPreviewTargetsWithReference` |`bool`      | Show a preview of the trial targets (unhittable) with the reference target. Make these targets hittable once the reference is destroyed |
+|`previewTargetColor`   |`Color3`               | Set the color to draw the preview targets with (before they are active)            |
 
 ```
 "targetHealthColors": [                         // Array of two colors to interpolate between for target health
@@ -354,6 +355,8 @@ These flags help control the behavior of click-to-photon monitoring in applicati
 "showReferenceTarget": true,                    // Show a reference target between trials
 "referenceTargetColor": Color3(1.0,1.0,1.0),    // Reference target color (return to "0" view direction)
 "referenceTargetSize": 0.01,                    // This is a size in meters
+"showPreviewTargetsWithReference" : false,      // Don't show the preview targets with the reference
+"previewTargetColor" = Color3(0.5, 0.5, 0.5),   // Use gray for preview targets (if they are shown)
 ```
 
 ### Target Health Bars

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1343,6 +1343,9 @@ public:
 	float           refTargetSize = 0.05f;								///< Size of the reference target
 	Color3          refTargetColor = Color3(1.0, 0.0, 0.0);				///< Default reference target color
 
+	bool			previewWithRef = false;								///< Show preview of per-trial targets with the reference
+	Color3			previewColor = Color3(0.5, 0.5, 0.5);				///< Color to show preview targets in
+
 	void load(AnyTableReader reader, int settingsVersion = 1) {
 		switch (settingsVersion) {
 		case 1:
@@ -1365,6 +1368,8 @@ public:
 			reader.getIfPresent("showReferenceTarget", showRefTarget);
 			reader.getIfPresent("referenceTargetSize", refTargetSize);
 			reader.getIfPresent("referenceTargetColor", refTargetColor);
+			reader.getIfPresent("showPreviewTargetsWithReference", previewWithRef);
+			reader.getIfPresent("previewTargetColor", previewColor);
 			break;
 		default:
 			throw format("Did not recognize settings version: %d", settingsVersion);
@@ -1390,9 +1395,11 @@ public:
 		if(forceAll || def.combatTextVelocity != combatTextVelocity)		a["floatingCombatTextVelocity"] = combatTextVelocity;
 		if(forceAll || def.combatTextFade != combatTextFade)				a["floatingCombatTextFade"] = combatTextFade;
 		if(forceAll || def.combatTextTimeout != combatTextTimeout)			a["floatingCombatTextTimeout"] = combatTextTimeout;
-		if (forceAll || def.showRefTarget != showRefTarget)					a["showRefTarget"] = showRefTarget;
+		if(forceAll || def.showRefTarget != showRefTarget)					a["showRefTarget"] = showRefTarget;
 		if(forceAll || def.refTargetSize != refTargetSize)					a["referenceTargetSize"] = refTargetSize;
 		if(forceAll || def.refTargetColor != refTargetColor)				a["referenceTargetColor"] = refTargetColor;
+		if(forceAll || def.previewWithRef != previewWithRef)				a["showPreviewTargetsWithReference"] = previewWithRef;
+		if(forceAll || def.previewColor != previewColor)					a["previewTargetColor"] = previewColor;
 		return a;
 	}
 };

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -1199,7 +1199,7 @@ void FPSciApp::onUserInput(UserInput* ui) {
 					m_weapon->setFiring(true);
 				}
 				// check for hit, add graphics, update target state
-				if ((sess->presentationState == PresentationState::task) && !m_userSettingsWindow->visible()) {
+				if ((sess->currentState == PresentationState::task) && !m_userSettingsWindow->visible()) {
 					if (sess->canFire()) {
 						fired = true;
 						sess->countShot();						// Count shots
@@ -1245,7 +1245,7 @@ void FPSciApp::onUserInput(UserInput* ui) {
 	}
 	
 	for (GKey dummyShoot : keyMap.map["dummyShoot"]) {
-		if (ui->keyPressed(dummyShoot) && (sess->presentationState == PresentationState::feedback)) {
+		if (ui->keyPressed(dummyShoot) && (sess->currentState == PresentationState::feedback)) {
 			Array<shared_ptr<Entity>> dontHit;
 			dontHit.append(m_explosions);
 			dontHit.append(sess->unhittableTargets());

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -1205,11 +1205,12 @@ void FPSciApp::onUserInput(UserInput* ui) {
 						sess->countShot();						// Count shots
 						Array<shared_ptr<Entity>> dontHit;
 						dontHit.append(m_explosions);
+						dontHit.append(sess->unhittableTargets());
 						Model::HitInfo info;
 						float hitDist = finf();
 						int hitIdx = -1;
 
-						shared_ptr<TargetEntity> target = m_weapon->fire(sess->targetArray(), hitIdx, hitDist, info, dontHit);			// Fire the weapon
+						shared_ptr<TargetEntity> target = m_weapon->fire(sess->hittableTargets(), hitIdx, hitDist, info, dontHit);			// Fire the weapon
 						if (isNull(target)) // Miss case
 						{
 							// Play scene hit sound
@@ -1247,10 +1248,11 @@ void FPSciApp::onUserInput(UserInput* ui) {
 		if (ui->keyPressed(dummyShoot) && (sess->presentationState == PresentationState::feedback)) {
 			Array<shared_ptr<Entity>> dontHit;
 			dontHit.append(m_explosions);
+			dontHit.append(sess->unhittableTargets());
 			Model::HitInfo info;
 			float hitDist = finf();
 			int hitIdx = -1;
-			shared_ptr<TargetEntity> target = m_weapon->fire(sess->targetArray(), hitIdx, hitDist, info, dontHit);			// Fire the weapon
+			shared_ptr<TargetEntity> target = m_weapon->fire(sess->hittableTargets(), hitIdx, hitDist, info, dontHit);			// Fire the weapon
 		}
 	}
 

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -138,7 +138,7 @@ void Session::initTargetAnimation() {
 
 	// In task state, spawn a test target. Otherwise spawn a target at straight ahead.
 	if (currentState == PresentationState::task) {
-		if (m_config->targetView.previewWithRef) {
+		if (m_config->targetView.previewWithRef && m_config->targetView.showRefTarget) {
 			// Activate the preview targets
 			const Color3 activeColor = m_config->targetView.healthColors[0];
 			for (shared_ptr<TargetEntity> target : m_targetArray) {
@@ -151,9 +151,9 @@ void Session::initTargetAnimation() {
 			spawnTrialTargets(initialSpawnPos);			// Spawn all the targets normally
 		}
 	}
-	else {
+	else { // State is feedback and we are spawning a reference target
 		CFrame f = CFrame::fromXYZYPRRadians(initialSpawnPos.x, initialSpawnPos.y, initialSpawnPos.z, -initialHeadingRadians, 0.0f, 0.0f);
-		// Make sure we reset the target color here (avoid color bugs)
+		// Spawn the reference target
 		auto t = spawnReferenceTarget(
 			f.pointToWorldSpace(Point3(0, 0, -m_targetDistance)),
 			initialSpawnPos,

--- a/source/Session.h
+++ b/source/Session.h
@@ -127,8 +127,12 @@ protected:
 	// Target management
 	Table<String, Array<shared_ptr<ArticulatedModel>>>* m_targetModels;
 	int m_modelScaleCount;
-	int m_lastUniqueID = 0;								///< Counter for creating unique names for various entities
-	Array<shared_ptr<TargetEntity>> m_targetArray;		///< Array of drawn targets
+	int m_lastUniqueID = 0;									///< Counter for creating unique names for various entities
+	
+	Array<shared_ptr<TargetEntity>> m_targetArray;			///< Array of drawn targets
+	Array<shared_ptr<TargetEntity>> m_hittableTargets;		///< Array of targets that can be hit
+	Array<shared_ptr<TargetEntity>> m_unhittableTargets;	///< Array of targets that can't be hit
+
 
 	int m_currTrialIdx;										///< Current trial
 	int m_currQuestionIdx = -1;								///< Current question index
@@ -339,7 +343,6 @@ public:
 	}
 
 	/** Destroy a target from the targets array */
-	void destroyTarget(int index);
 	void destroyTarget(shared_ptr<TargetEntity> target);
 
 	/** clear all targets (used when clearing remaining targets at the end of a trial) */
@@ -368,24 +371,12 @@ public:
 	}
 
 	/** dynamically allocates a new array of pointers to the hittable targets in the session */
-	const Array<shared_ptr<TargetEntity>> hittableTargets() const {
-		Array<shared_ptr<TargetEntity>> hittable;
-		for (shared_ptr<TargetEntity> target: m_targetArray) {
-			if (target->canHit()) {
-				hittable.append(target);
-			}
-		}
-		return hittable;
+	const Array<shared_ptr<TargetEntity>>& hittableTargets() const {
+		return m_hittableTargets;
 	}
 
 	/** dynamically allocates a new array of pointers to the unhittable (visible but inactive) targets in the session */
-	const Array<shared_ptr<TargetEntity>> unhittableTargets() const {
-		Array<shared_ptr<TargetEntity>> unhittable;
-		for (shared_ptr<TargetEntity> target : m_targetArray) {
-			if (!target->canHit()) {
-				unhittable.append(target);
-			}
-		}
-		return unhittable;
+	const Array<shared_ptr<TargetEntity>>& unhittableTargets() const {
+		return m_unhittableTargets;
 	}
 };

--- a/source/Session.h
+++ b/source/Session.h
@@ -304,6 +304,7 @@ public:
 
 	void randomizePosition(const shared_ptr<TargetEntity>& target) const;
 	void initTargetAnimation();
+	void spawnTrialTargets(Point3 initialSpawnPos, bool previewMode = false);
 	float weaponCooldownPercent() const;
 	RealTime lastFireTime() const {
 		return m_lastFireAt;
@@ -363,5 +364,25 @@ public:
 
 	const Array<shared_ptr<TargetEntity>>& targetArray() const {
 		return m_targetArray;
+	}
+
+	const Array<shared_ptr<TargetEntity>> hittableTargets() const {
+		Array<shared_ptr<TargetEntity>> hittable;
+		for (shared_ptr<TargetEntity> target: m_targetArray) {
+			if (target->canHit()) {
+				hittable.append(target);
+			}
+		}
+		return hittable;
+	}
+
+	const Array<shared_ptr<TargetEntity>> unhittableTargets() const {
+		Array<shared_ptr<TargetEntity>> unhittable;
+		for (shared_ptr<TargetEntity> target : m_targetArray) {
+			if (!target->canHit()) {
+				unhittable.append(target);
+			}
+		}
+		return unhittable;
 	}
 };

--- a/source/Session.h
+++ b/source/Session.h
@@ -312,7 +312,8 @@ public:
 	int remainingAmmo() const;
 
 	bool blockComplete() const;
-	void nextCondition();
+	bool nextCondition();
+	bool hasNextCondition() const;
 
 	void endLogging();
 
@@ -357,7 +358,7 @@ public:
 	bool updateBlock(bool updateTargets = false);
 
 	bool moveOn = false;								///< Flag indicating session is complete
-	enum PresentationState presentationState;			///< Current presentation state
+	enum PresentationState currentState;			///< Current presentation state
 
 	/** result recording */
 	void countShot() { m_shotCount++; }

--- a/source/Session.h
+++ b/source/Session.h
@@ -367,6 +367,7 @@ public:
 		return m_targetArray;
 	}
 
+	/** dynamically allocates a new array of pointers to the hittable targets in the session */
 	const Array<shared_ptr<TargetEntity>> hittableTargets() const {
 		Array<shared_ptr<TargetEntity>> hittable;
 		for (shared_ptr<TargetEntity> target: m_targetArray) {
@@ -377,6 +378,7 @@ public:
 		return hittable;
 	}
 
+	/** dynamically allocates a new array of pointers to the unhittable (visible but inactive) targets in the session */
 	const Array<shared_ptr<TargetEntity>> unhittableTargets() const {
 		Array<shared_ptr<TargetEntity>> unhittable;
 		for (shared_ptr<TargetEntity> target : m_targetArray) {

--- a/source/TargetEntity.h
+++ b/source/TargetEntity.h
@@ -67,6 +67,7 @@ protected:
 	int		m_scaleIdx			= 0;				///< Index for scaled model
 	bool	m_isLogged			= true;				///< Control flag for logging
 	Point3	m_offset;								///< Offset for initial spawn
+	bool	m_canHit			= true;				///< Can this target be hit?	
 	Array<Destination> m_destinations;				///< Array of destinations to visit
 	shared_ptr<Sound> m_hitSound;					///< Sound to play when hit
 	float m_hitSoundVol;							///< Volume to play hit sound at
@@ -121,6 +122,7 @@ public:
 	}
 
 	void setWorldSpace(bool worldSpace) { m_worldSpace = worldSpace; }
+	void setCanHit(bool active) { m_canHit = active; }
 
 	void setHitSound(const String& hitSoundFilename, float hitSoundVol = 1.0f) {
 		if (hitSoundFilename == "") { m_hitSound = nullptr; }
@@ -194,8 +196,10 @@ public:
 	Array<Destination> destinations() const { return m_destinations; }
 	/** Getter for remaining respawn count */
 	int respawnsRemaining() const { return m_respawnCount; }
-	/** Getter for parmaeter index */
+	/** Getter for parameter index */
 	int paramIdx() const { return m_paramIdx; }
+	/** Getter for active/can hit */
+	bool canHit() const { return m_canHit; }
 
 	void drawHealthBar(RenderDevice* rd, const Camera& camera, const Framebuffer& framebuffer, Point2 size, Point3 offset, Point2 border, Array<Color4> colors, Color4 borderColor) const;
 	virtual void onSimulation(SimTime absoluteTime, SimTime deltaTime) override;

--- a/tests/FPSciTests.cpp
+++ b/tests/FPSciTests.cpp
@@ -274,7 +274,7 @@ TEST_F(FPSciTests, TestTargetPositions) {
 }
 
 TEST_F(FPSciTests, CanDetectWhichTargets) {
-	EXPECT_EQ(s_app->sess->presentationState, PresentationState::task);
+	EXPECT_EQ(s_app->sess->currentState, PresentationState::task);
 
 	respawnTargets();
 
@@ -285,7 +285,7 @@ TEST_F(FPSciTests, CanDetectWhichTargets) {
 }
 
 TEST_F(FPSciTests, KillTargetFront) {
-	EXPECT_EQ(s_app->sess->presentationState, PresentationState::task);
+	EXPECT_EQ(s_app->sess->currentState, PresentationState::task);
 
 	respawnTargets();
 
@@ -305,7 +305,7 @@ TEST_F(FPSciTests, KillTargetFront) {
 }
 
 TEST_F(FPSciTests, KillTargetFrontHoldclick) {
-	EXPECT_EQ(s_app->sess->presentationState, PresentationState::task);
+	EXPECT_EQ(s_app->sess->currentState, PresentationState::task);
 	respawnTargets();
 	zeroCameraRotation();
 	s_fakeInput->window().injectMouseDown(0);
@@ -320,7 +320,7 @@ TEST_F(FPSciTests, KillTargetFrontHoldclick) {
 }
 
 TEST_F(FPSciTests, KillTargetRightRotate) {
-	EXPECT_EQ(s_app->sess->presentationState, PresentationState::task);
+	EXPECT_EQ(s_app->sess->currentState, PresentationState::task);
 	respawnTargets();
 
 	// Kill the right target by rotating to line it up
@@ -338,7 +338,7 @@ TEST_F(FPSciTests, KillTargetRightRotate) {
 }
 
 TEST_F(FPSciTests, KillTargetRightTranslate) {
-	EXPECT_EQ(s_app->sess->presentationState, PresentationState::task);
+	EXPECT_EQ(s_app->sess->currentState, PresentationState::task);
 	respawnTargets();
 
 	zeroCameraRotation();
@@ -365,7 +365,7 @@ TEST_F(FPSciTests, KillTargetRightTranslate) {
 }
 
 TEST_F(FPSciTests, ResetCamera) {
-	EXPECT_EQ(s_app->sess->presentationState, PresentationState::task);
+	EXPECT_EQ(s_app->sess->currentState, PresentationState::task);
 
 	// Move the camera off zero
 	zeroCameraRotation();
@@ -386,7 +386,7 @@ TEST_F(FPSciTests, ResetCamera) {
 }
 
 TEST_F(FPSciTests, RotateCamera) {
-	EXPECT_EQ(s_app->sess->presentationState, PresentationState::task);
+	EXPECT_EQ(s_app->sess->currentState, PresentationState::task);
 	zeroCameraRotation();
 	s_app->oneFrame();
 
@@ -411,7 +411,7 @@ TEST_F(FPSciTests, RotateCamera) {
 }
 
 TEST_F(FPSciTests, MoveCamera) {
-	EXPECT_EQ(s_app->sess->presentationState, PresentationState::task);
+	EXPECT_EQ(s_app->sess->currentState, PresentationState::task);
 	zeroCameraRotation();
 	s_app->oneFrame();
 	EXPECT_EQ(s_app->simStepDuration(), GApp::MATCH_REAL_TIME_TARGET);
@@ -452,7 +452,7 @@ TEST_F(FPSciTests, MoveCamera) {
 }
 
 TEST_F(FPSciTests, TestAutoFire) {
-	EXPECT_EQ(s_app->sess->presentationState, PresentationState::task);
+	EXPECT_EQ(s_app->sess->currentState, PresentationState::task);
 	respawnTargets();
 	zeroCameraRotation();
 


### PR DESCRIPTION
This branch adds support for showing a user "previews" of real targets while the reference target is being drawn. The feature is enabled using the `showPreviewTargetsWithReference` flag in a session/experiment config.

The preview targets can be delineated from "real" targets using their color (settable with the `previewTargetColor` parameter in the session/experiment config).

Merging this PR closes #187.