### PR TITLE
Per trial feedback unconditional of session description

### DIFF
--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -193,14 +193,10 @@ void Session::processResponse()
 	// Check for whether all targets have been destroyed
 	if (m_destroyedTargets == totalTargets) {
 		m_totalRemainingTime += (double(m_config->timing.taskDuration) - m_taskExecutionTime);
-		if (m_config->description == "training") {
-			m_feedbackMessage = formatFeedback(m_config->feedback.trialSuccess);
-		}
+		m_feedbackMessage = formatFeedback(m_config->feedback.trialSuccess);
 	}
 	else {
-		if (m_config->description == "training") {
-			m_feedbackMessage = formatFeedback(m_config->feedback.trialFailure);
-		}
+		m_feedbackMessage = formatFeedback(m_config->feedback.trialFailure);
 	}
 }
 


### PR DESCRIPTION
This branch removes the requirement on the session config's `description` being `"training"` in order to print per trial feedback. Sessions that should not include per trial feedback can remove feedback messages by setting the `trialSuccessFeedback` and `trialFailureFeedback` to empty strings.

Alternatively (if desired) we can make the default per trial feedback strings empty.

Merging this PR closes #185.