### PR TITLE
Foreground and blocking commands

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -469,29 +469,49 @@ These flags control whether various information is written to the output databas
 ## Command Config
 In addition to the programmable behavior above the general config also supports running of arbitrary commands around the FPSci runtime. Note that the "end" commands keep running and there's the potential for orphaned processes if you specify commands that are long running or infinite. The command options include:
 
-| Parameter Name                    | Type              | Description                                                                                  |
-|-----------------------------------|-------------------|----------------------------------------------------------------------------------------------|
-|`commandsOnSessionStart`           |`Array<String>`    | Command(s) to run at the start of a new session. Command(s) quit on session end              |
-|`commandsOnSessionEnd`             |`Array<String>`    | Command(s) to run at the end of a new session. Command(s) not forced to quit                 |
-|`commandsOnTrialStart`             |`Array<String>`    | Command(s) to run at the start of a new trial within a session. Command(s) quit on trial end |
-|`commandsOnTrialEnd`               |`Array<String>`    | Command(s) to run at the end of a new trial within a session. Command(s) not forced to quit  |
+| Parameter Name                    | Type                  | Description                                                                                   |
+|-----------------------------------|------------------------|----------------------------------------------------------------------------------------------|
+|`commandsOnSessionStart`           |`Array<CommandSpec>`    | Command(s) to run at the start of a new session. Command(s) quit on session end              |
+|`commandsOnSessionEnd`             |`Array<CommandSpec>`    | Command(s) to run at the end of a new session. Command(s) not forced to quit                 |
+|`commandsOnTrialStart`             |`Array<CommandSpec>`    | Command(s) to run at the start of a new trial within a session. Command(s) quit on trial end |
+|`commandsOnTrialEnd`               |`Array<CommandSpec>`    | Command(s) to run at the end of a new trial within a session. Command(s) not forced to quit  |
 
-Note that the `Array` of commands provided for each of the parameters above is ordered, but the commands are launched (nearly) simultaneously in a non-blocking manner. This means that run order within a set of commands cannot be strictly guaranteed. If you have serial dependencies within a list of commands consider using a script to sequence them.
+Note that the `Array` of commands provided for each of the parameters above is ordered, but the commands are launched (nearly) simultaneously. This means that run order within a set of commands cannot be strictly guaranteed. If you have serial dependencies within a list of commands consider using a script to sequence them.
+
+### Command Specification
+Each command is specified using a `CommandSpec` which itself supports sub-fields for configuration:
+| Parameter Name    | Type        | Description                                                                                 |
+|-------------------|------------|----------------------------------------------------------------------------------------------|
+|`command`          |`String`    | Command string to run                                                                        |
+|`foreground`       |`bool`      | Run this command in the foreground? (By default commands are silent/background tasks)        |
+|`blocking`         |`bool`      | Block on this command being complete (forces command sequencing)                             |
 
 For example, the following will cause session start, session end, trial start and trial end strings to be written to a `commandLog.txt` file.
 
 ```
-commandsOnSessionStart = ( "cmd /c echo Session start>> commandLog.txt", "cmd /c echo Session start second command>> commandLog.txt" );
-commandsOnSessionEnd = ( "cmd /c echo Session end>> commandLog.txt", "cmd /c echo Session end second command>> commandLog.txt" );
-commandsOnTrialStart = ( "cmd /c echo Trial start>> commandLog.txt" );
-commandsOnTrialEnd = ( "cmd /c echo Trial end>> commandLog.txt" );
+commandsOnSessionStart = ( 
+    { command = "cmd /c echo Session start>> commandLog.txt", blocking = true },
+    { command = "cmd /c echo Session start second command>> commandLog.txt"} 
+);
+commandsOnSessionEnd = (
+    { command = "cmd /c echo Session end>> commandLog.txt", blocking = true }, 
+    { "cmd /c echo Session end second command>> commandLog.txt" }
+);
+commandsOnTrialStart = ( { command = {"cmd /c echo Trial start>> commandLog.txt" } );
+commandsOnTrialEnd = ( { command = "cmd /c echo Trial end>> commandLog.txt" } );
 ```
 
 Another common use would be to run a python script/code at the start or end of a session. For example:
 
 ```
-commandsOnSessionStart = ( "python \"../scripts/event logger/event_logger.py\"" );
-commandsOnSessionEnd = ( "python -c \"f = open('texttest.txt', 'w'); f.write('Hello world!'); f.close()\"" );
+commandsOnSessionStart = ( { command = "python \"../scripts/event logger/event_logger.py\"" } );
+commandsOnSessionEnd = ( { command = "python -c \"f = open('texttest.txt', 'w'); f.write('Hello world!'); f.close()\"", blocking = true } );
+```
+
+Alternatively, to open a web page at the end of a session you could use:
+
+```
+commandsOnSessionEnd = ( { command = "cmd /c start [webpage URL]", foreground = true } );
 ```
 
 # Frame Rate Modes

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -495,7 +495,7 @@ commandsOnSessionStart = (
 );
 commandsOnSessionEnd = (
     { command = "cmd /c echo Session end>> commandLog.txt", blocking = true }, 
-    { "cmd /c echo Session end second command>> commandLog.txt" }
+    { command = "cmd /c echo Session end second command>> commandLog.txt" }
 );
 commandsOnTrialStart = ( { command = "cmd /c echo Trial start>> commandLog.txt" } );
 commandsOnTrialEnd = ( { command = "cmd /c echo Trial end>> commandLog.txt" } );

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -497,7 +497,7 @@ commandsOnSessionEnd = (
     { command = "cmd /c echo Session end>> commandLog.txt", blocking = true }, 
     { "cmd /c echo Session end second command>> commandLog.txt" }
 );
-commandsOnTrialStart = ( { command = {"cmd /c echo Trial start>> commandLog.txt" } );
+commandsOnTrialStart = ( { command = "cmd /c echo Trial start>> commandLog.txt" } );
 commandsOnTrialEnd = ( { command = "cmd /c echo Trial end>> commandLog.txt" } );
 ```
 

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1594,10 +1594,17 @@ public:
 
 	CommandSpec() {}
 	CommandSpec(const Any& any){
-		AnyTableReader reader(any);
-		reader.get("command", cmdStr, "A command string must be specified!");
-		reader.getIfPresent("foreground", foreground);
-		reader.getIfPresent("blocking", blocking);
+		try {
+			AnyTableReader reader(any);
+			reader.get("command", cmdStr, "A command string must be specified!");
+			reader.getIfPresent("foreground", foreground);
+			reader.getIfPresent("blocking", blocking);
+		}
+		catch (ParseError e) {
+			// Handle errors related to older (pure) string-based commands
+			e.message = "Commands must be specified using a valid CommandSpec (refer to the general_config.md file for more information)!\n" + e.message;
+			throw e;
+		}
 	}
 
 	Any toAny(const bool forceAll = true) const {

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1586,12 +1586,37 @@ public:
 	}
 };
 
+class CommandSpec {
+public:
+	String	cmdStr;										///< Command string
+	bool foreground = false;							///< Flag to indicate foreground vs background
+	bool blocking = false;								///< Flag to indicate to block on this process complete
+
+	CommandSpec() {}
+	CommandSpec(const Any& any){
+		AnyTableReader reader(any);
+		reader.get("command", cmdStr, "A command string must be specified!");
+		reader.getIfPresent("foreground", foreground);
+		reader.getIfPresent("blocking", blocking);
+	}
+
+	Any toAny(const bool forceAll = true) const {
+		Any a(Any::TABLE);
+		CommandSpec def;
+		a["command"] = cmdStr;
+		if (forceAll || def.foreground != foreground)	a["foreground"] = foreground;
+		if (forceAll || def.blocking != blocking)		a["blocking"] = blocking;
+		return a;
+	}
+
+};
+
 class CommandConfig {
 public: 
-	Array<String> sessionStartCmds;						///< Command to run on start of a session
-	Array<String> sessionEndCmds;						///< Command to run on end of a session
-	Array<String> trialStartCmds;						///< Command to run on start of a trial
-	Array<String> trialEndCmds;							///< Command to run on end of a trial
+	Array<CommandSpec> sessionStartCmds;				///< Command to run on start of a session
+	Array<CommandSpec> sessionEndCmds;						///< Command to run on end of a session
+	Array<CommandSpec> trialStartCmds;						///< Command to run on start of a trial
+	Array<CommandSpec> trialEndCmds;							///< Command to run on end of a trial
 
 	void load(AnyTableReader reader, int settingsVersion = 1) {
 		switch (settingsVersion) {

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1602,7 +1602,10 @@ public:
 		}
 		catch (ParseError e) {
 			// Handle errors related to older (pure) string-based commands
-			e.message = "Commands must be specified using a valid CommandSpec (refer to the general_config.md file for more information)!\n" + e.message;
+			e.message += "\nCommands must be specified using a valid CommandSpec!\n";
+			e.message += "Refer to the general_config.md file for more information.\n";
+			e.message += "If migrating from an older experiment config, use the following syntax.\n";
+			e.message += "commandsOnTrialStart = ( { command = \"cmd / c echo Trial start >> commandLog.txt\" } );\n";
 			throw e;
 		}
 	}

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1604,8 +1604,8 @@ public:
 			// Handle errors related to older (pure) string-based commands
 			e.message += "\nCommands must be specified using a valid CommandSpec!\n";
 			e.message += "Refer to the general_config.md file for more information.\n";
-			e.message += "If migrating from an older experiment config, use the following syntax.\n";
-			e.message += "commandsOnTrialStart = ( { command = \"cmd / c echo Trial start >> commandLog.txt\" } );\n";
+			e.message += "If migrating from an older experiment config, use the following syntax:\n";
+			e.message += "commandsOnTrialStart = ( { command = \"cmd /c echo Trial start>> commandLog.txt\" } );\n";
 			throw e;
 		}
 	}


### PR DESCRIPTION
This branch adds support for a `CommandSpec` which allows the experiment designer to specify `foreground` and `blocking` flags for any given command.

This slightly modifies the syntax for specifying command arrays in the experiment config file from:

```
commandsOnSessionEnd = [ "testcommand.exe" ];
```
to
```
commandsOnSessionEnd = [ { command = "testcommand.exe" } ];
```

This restructure allows the `foreground` and `blocking` parameters to be specified along with the `command`. For example, to open a foreground browser with a web page at the end of a session, the designer can specify:

```
commandsOnSessionEnd = [ { command = "cmd /c start [webpage URL]", foreground = true } ];
```