### PR TITLE
Refactor system/latency logger config

### DIFF
--- a/FPSci.lib.vcxproj
+++ b/FPSci.lib.vcxproj
@@ -178,7 +178,6 @@
     <None Include="data-files\keymap.Any" />
     <None Include="data-files\shader\distort.pix" />
     <None Include="data-files\startupconfig.Any" />
-    <None Include="data-files\systemconfig.Any" />
     <None Include="data-files\userconfig.Any" />
     <None Include="data-files\userstatus.Any" />
   </ItemGroup>

--- a/FPSci.lib.vcxproj
+++ b/FPSci.lib.vcxproj
@@ -178,6 +178,7 @@
     <None Include="data-files\keymap.Any" />
     <None Include="data-files\shader\distort.pix" />
     <None Include="data-files\startupconfig.Any" />
+    <None Include="data-files\systemconfig.Any" />
     <None Include="data-files\userconfig.Any" />
     <None Include="data-files\userstatus.Any" />
   </ItemGroup>

--- a/FPSci.lib.vcxproj.filters
+++ b/FPSci.lib.vcxproj.filters
@@ -111,9 +111,6 @@
     <None Include="data-files\shader\distort.pix">
       <Filter>Shader Files</Filter>
     </None>
-    <None Include="data-files\systemconfig.Any">
-      <Filter>Config Files</Filter>
-    </None>
     <None Include="data-files\userstatus.Any">
       <Filter>Config Files</Filter>
     </None>

--- a/FPSci.lib.vcxproj.filters
+++ b/FPSci.lib.vcxproj.filters
@@ -120,5 +120,8 @@
     <None Include="data-files\keymap.Any">
       <Filter>Config Files</Filter>
     </None>
+    <None Include="data-files\systemconfig.Any">
+      <Filter>Config Files</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -317,18 +317,18 @@ No static HUD elements are drawn by default. An example snippet including 2 (non
 These flags support the reseach hardware latency logger:
 | Parameter Name     |Units                 | Description                                                                        |
 |--------------------|----------------------|------------------------------------------------------------------------------------|
-|`HasLatencyLogger`  |`bool`    | Whether this system has a click-to-photon logger connected, when set to `false` this parameter disables all calls to hardware logging scripts |
-|`LoggerComPort`     |`String`  | The port on which the logger is connected when `HasLogger` is set to `true`. Generally speaking this is a string (i.e. on windows `COM[X]`) |
-|`HasLatencyLoggerSync` |`bool` | Whether the system has an additional serial card where the DTR signal will be used for timebase syncing the logger to the PC (if `HasLatencyLogger` is `true` and `HasLatencyLoggerSync` is false, the first USB packet exchanged through the system is used to create the timestamp at a lower precision). |
-|`LoggerSyncComPort` |`String`  | The port on which the sync card is connected if `HasLatencyLoggerSync` is set to `true`. Generally speaking these ports tend to be enumerated at lower port numbers (i.e. `COM0` or `COM1`) than the Virtual COM Ports (VCPs) produced by USB. |
+|`hasLatencyLogger`  |`bool`    | Whether this system has a click-to-photon logger connected, when set to `false` this parameter disables all calls to hardware logging scripts |
+|`loggerComPort`     |`String`  | The port on which the logger is connected when `hasLogger` is set to `true`. Generally speaking this is a string (i.e. on windows `COM[X]`) |
+|`hasLatencyLoggerSync` |`bool` | Whether the system has an additional serial card where the DTR signal will be used for timebase syncing the logger to the PC (if `hasLatencyLogger` is `true` and `hasLatencyLoggerSync` is false, the first USB packet exchanged through the system is used to create the timestamp at a lower precision). |
+|`loggerSyncComPort` |`String`  | The port on which the sync card is connected if `hasLatencyLoggerSync` is set to `true`. Generally speaking these ports tend to be enumerated at lower port numbers (i.e. `COM0` or `COM1`) than the Virtual COM Ports (VCPs) produced by USB. |
 
 An example of this structure's usage is provided below:
 
 ```
-"HasLatencyLogger" :  true,
-"LoggerComPort" : "COM3",
-"HasLatencyLoggerSync": true,
-"LoggerSyncComPort" : "COM1",
+"hasLatencyLogger" :  true,
+"loggerComPort" : "COM3",
+"hasLatencyLoggerSync": true,
+"loggerSyncComPort" : "COM1",
 ```
 
 ## Click to Photon Monitoring
@@ -510,6 +510,22 @@ Another common use would be to run a python script/code at the start or end of a
 ```
 commandsOnSessionStart = ( "python \"../scripts/event logger/event_logger.py\"" );
 commandsOnSessionEnd = ( "python -c \"f = open('texttest.txt', 'w'); f.write('Hello world!'); f.close()\"" );
+```
+
+### Supported Substrings
+In addition to the basic commands provided above several replacable substrings are supported in commands. These include:
+
+| Substring         | Description                                                           |
+|-------------------|-----------------------------------------------------------------------|
+|`%loggerComPort`   | The logger COM port (optionally) provided in a general config         |
+|`%loggerSyncComPort`|  The logger sync COM port (optionally) provided in a general config  |
+
+Note that if either of these substrings is specified in a command, but empty/not provided in the experiment config file an exception will be thrown.
+
+An example of their use is provided below:
+
+```
+commandOnSessionStart = ( "python ../scripts/my_logger_script.py %loggerComPort" );
 ```
 
 # Frame Rate Modes

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -313,6 +313,24 @@ No static HUD elements are drawn by default. An example snippet including 2 (non
 ]
 ```
 
+## Latency Logger
+These flags support the reseach hardware latency logger:
+| Parameter Name     |Units                 | Description                                                                        |
+|--------------------|----------------------|------------------------------------------------------------------------------------|
+|`HasLatencyLogger`  |`bool`    | Whether this system has a click-to-photon logger connected, when set to `false` this parameter disables all calls to hardware logging scripts |
+|`LoggerComPort`     |`String`  | The port on which the logger is connected when `HasLogger` is set to `true`. Generally speaking this is a string (i.e. on windows `COM[X]`) |
+|`HasLatencyLoggerSync` |`bool` | Whether the system has an additional serial card where the DTR signal will be used for timebase syncing the logger to the PC (if `HasLatencyLogger` is `true` and `HasLatencyLoggerSync` is false, the first USB packet exchanged through the system is used to create the timestamp at a lower precision). |
+|`LoggerSyncComPort` |`String`  | The port on which the sync card is connected if `HasLatencyLoggerSync` is set to `true`. Generally speaking these ports tend to be enumerated at lower port numbers (i.e. `COM0` or `COM1`) than the Virtual COM Ports (VCPs) produced by USB. |
+
+An example of this structure's usage is provided below:
+
+```
+"HasLatencyLogger" :  true,
+"LoggerComPort" : "COM3",
+"HasLatencyLoggerSync": true,
+"LoggerSyncComPort" : "COM1",
+```
+
 ## Click to Photon Monitoring
 These flags help control the behavior of click-to-photon monitoring in application:
 

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -313,24 +313,6 @@ No static HUD elements are drawn by default. An example snippet including 2 (non
 ]
 ```
 
-## Latency Logger
-These flags support the reseach hardware latency logger:
-| Parameter Name     |Units                 | Description                                                                        |
-|--------------------|----------------------|------------------------------------------------------------------------------------|
-|`hasLatencyLogger`  |`bool`    | Whether this system has a click-to-photon logger connected, when set to `false` this parameter disables all calls to hardware logging scripts |
-|`loggerComPort`     |`String`  | The port on which the logger is connected when `hasLogger` is set to `true`. Generally speaking this is a string (i.e. on windows `COM[X]`) |
-|`hasLatencyLoggerSync` |`bool` | Whether the system has an additional serial card where the DTR signal will be used for timebase syncing the logger to the PC (if `hasLatencyLogger` is `true` and `hasLatencyLoggerSync` is false, the first USB packet exchanged through the system is used to create the timestamp at a lower precision). |
-|`loggerSyncComPort` |`String`  | The port on which the sync card is connected if `hasLatencyLoggerSync` is set to `true`. Generally speaking these ports tend to be enumerated at lower port numbers (i.e. `COM0` or `COM1`) than the Virtual COM Ports (VCPs) produced by USB. |
-
-An example of this structure's usage is provided below:
-
-```
-"hasLatencyLogger" :  true,
-"loggerComPort" : "COM3",
-"hasLatencyLoggerSync": true,
-"loggerSyncComPort" : "COM1",
-```
-
 ## Click to Photon Monitoring
 These flags help control the behavior of click-to-photon monitoring in application:
 
@@ -512,7 +494,7 @@ commandsOnSessionStart = ( "python \"../scripts/event logger/event_logger.py\"" 
 commandsOnSessionEnd = ( "python -c \"f = open('texttest.txt', 'w'); f.write('Hello world!'); f.close()\"" );
 ```
 
-### Supported Substrings
+### Supported Substrings for Commands
 In addition to the basic commands provided above several replacable substrings are supported in commands. These include:
 
 | Substring         | Description                                                           |

--- a/docs/systemConfigReadme.md
+++ b/docs/systemConfigReadme.md
@@ -1,18 +1,5 @@
 # System Configuration
-The system configuration file provides configuration information related to the hardware setup of the machine (namely whether a hardware click-to-photon logger and it's affiliated serial sync card is present and if so which COM port each uses).
-
-## File Location
-The `systemconfig.Any` file is located in the [`data-files` directory](../data-files/) at the top of the project. If no `systemconfig.Any` file is present at startup the application writes a default config (which assumes no hardware latency logger is present) to `systemconfig.Any`.
-
-# Input Fields
-The following fields are input to the `systemconfig.Any` file:
-
-* `HasLogger` indicates whether this system will perform any click-to-photon logging, when set to `false` this parameter disables all calls to hardware logging scripts.
-* `LoggerComPort` indicates the port on which the logger is connected when `HasLogger` is set to `true`. Generally speaking this is a string (i.e. on windows `COM[X]`)
-* `HasSync` indicates whether the system has an additional serial card where the DTR signal will be used for timebase syncing the logger to the PC (if `HasLogger` is `true` and `HasSync` is false, the first USB packet exchanged through the system is used to create the timestamp at a lower precision).
-* `SyncComPort` indicates the port on which the sync card is connected if `HasSync` is set to `true`. Generally speaking these ports tend to be enumerated at lower port numbers (i.e. `COM0` or `COM1`) than the Virtual COM Ports (VCPs) produced by USB.
-
-`LoggerComPort` and `SyncComPort` are ignored if their affiliated `HasLogger`/`HasSync` fields are not set to `true`.
+The system configuration file is now depricated. It's input (config fields) have been moved to the [Latency Logger Config within the general config](general_config.md#latency-logger) and it's (historical) outputs have been redirected to `log.txt`.
 
 # (Historical) Output Fields
 The following fields were (historically) written by the application as output from the `systemconfig.Any` file, but are no longer:

--- a/docs/systemConfigReadme.md
+++ b/docs/systemConfigReadme.md
@@ -1,5 +1,25 @@
 # System Configuration
-The system configuration file is now depricated. It's input (config fields) have been moved to the [Latency Logger Config within the general config](general_config.md#latency-logger) and it's (historical) outputs have been redirected to `log.txt`.
+The system configuration file supports details specific a given computer. This file's (historical) outputs have been redirected to `log.txt`.
+
+# Latency Logger Support
+These flags support the reseach hardware latency logger:
+| Parameter Name     |Units                 | Description                                                                        |
+|--------------------|----------------------|------------------------------------------------------------------------------------|
+|`hasLatencyLogger`  |`bool`    | Whether this system has a click-to-photon logger connected, when set to `false` this parameter disables all calls to hardware logging scripts |
+|`loggerComPort`     |`String`  | The port on which the logger is connected when `hasLogger` is set to `true`. Generally speaking this is a string (i.e. on windows `COM[X]`) |
+|`hasLatencyLoggerSync` |`bool` | Whether the system has an additional serial card where the DTR signal will be used for timebase syncing the logger to the PC (if `hasLatencyLogger` is `true` and `hasLatencyLoggerSync` is false, the first USB packet exchanged through the system is used to create the timestamp at a lower precision). |
+|`loggerSyncComPort` |`String`  | The port on which the sync card is connected if `hasLatencyLoggerSync` is set to `true`. Generally speaking these ports tend to be enumerated at lower port numbers (i.e. `COM0` or `COM1`) than the Virtual COM Ports (VCPs) produced by USB. |
+
+An example of this structure's usage is provided below:
+
+```
+"hasLatencyLogger" :  true,
+"loggerComPort" : "COM3",
+"hasLatencyLoggerSync": true,
+"loggerSyncComPort" : "COM1",
+```
+
+The `loggerComPort` and `loggerSyncComPort` fields can be used in [commands](general_config.md#supported-substrings-for-commands) via their affiliaied `%loggerComPort` and `%loggerSyncComPort` replacement substrings. 
 
 # (Historical) Output Fields
 The following fields were (historically) written by the application as output from the `systemconfig.Any` file, but are no longer:

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -309,9 +309,9 @@ public:
 	/** Serialize to Any */
 	Any addToAny(Any a, const bool forceAll = true) const{
 		LatencyLoggerConfig def;
-		if(forceAll || def.hasLogger != hasLogger)			a["HasLogger"] = hasLogger;
+		if(forceAll || def.hasLogger != hasLogger)			a["HasLatencyLogger"] = hasLogger;
 		if(forceAll || def.loggerComPort != loggerComPort)	a["LoggerComPort"] = loggerComPort;
-		if(forceAll || def.hasSync != hasSync)				a["HasLoggerSync"] = hasSync;
+		if(forceAll || def.hasSync != hasSync)				a["HasLatencyLoggerSync"] = hasSync;
 		if(forceAll || def.syncComPort != syncComPort)		a["LoggerSyncComPort"] = syncComPort;
 		return a;
 	}

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -290,14 +290,20 @@ public:
 
 		switch (settingsVersion) {
 		case 1:
-			reader.getIfPresent("HasLatencyLogger", hasLogger);
+			reader.getIfPresent("hasLatencyLogger", hasLogger);
 			if (hasLogger) {
-				reader.get("LoggerComPort", loggerComPort, "Logger COM port must be provided if HasLogger = true!");
+				reader.get("loggerComPort", loggerComPort, "Logger COM port must be provided if \"hasLogger\" = true!");
+			}
+			else {
+				reader.getIfPresent("loggerComPort", loggerComPort);
 			}
 
-			reader.getIfPresent("HasLatencyLoggerSync", hasSync);
+			reader.getIfPresent("hasLatencyLoggerSync", hasSync);
 			if (hasSync) {
-				reader.get("LoggerSyncComPort", syncComPort, "Logger sync COM port must be provided if HasLoggerSync = true!");
+				reader.get("loggerSyncComPort", syncComPort, "Logger sync COM port must be provided if \"hasLoggerSync\" = true!");
+			}
+			else {
+				reader.getIfPresent("loggerSyncComPort", syncComPort);
 			}
 			break;
 		default:

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -46,8 +46,7 @@ void FPSciApp::onInit() {
 	info.printToLog();										// Print system info to log.txt
 
 	// Get and save system configuration
-	latencyLoggerConfig = LatencyLoggerConfig::load();
-	latencyLoggerConfig.printToLog();						// Print the latency logger config to log.txt								
+	experimentConfig.latencyLogger.printToLog();			// Print the latency logger config to log.txt								
 
 	// Get the size of the primary display
 	displayRes = OSWindow::primaryDisplaySize();						
@@ -456,12 +455,12 @@ void FPSciApp::updateSession(const String& id) {
 		FileSystem::createDirectory(startupConfig.resultsDirPath);
 	}
 	const String logName = startupConfig.resultsDirPath + id + "_" + userStatusTable.currentUser + "_" + String(FPSciLogger::genFileTimestamp());
-	if (latencyLoggerConfig.hasLogger) {
+	if (sessConfig->latencyLogger.hasLogger) {
 		if (!sessConfig->clickToPhoton.enabled) {
 			logPrintf("WARNING: Using a click-to-photon logger without the click-to-photon region enabled!\n\n");
 		}
 		if (m_pyLogger == nullptr) {
-			m_pyLogger = PythonLogger::create(latencyLoggerConfig.loggerComPort, latencyLoggerConfig.hasSync, latencyLoggerConfig.syncComPort);
+			m_pyLogger = PythonLogger::create(sessConfig->latencyLogger.loggerComPort, sessConfig->latencyLogger.hasSync, sessConfig->latencyLogger.syncComPort);
 		}
 		else {
 			// Handle running logger if we need to (terminate then merge results)

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -45,8 +45,9 @@ void FPSciApp::onInit() {
 	SystemInfo info = SystemInfo::get();
 	info.printToLog();										// Print system info to log.txt
 
-	// Get and save system configuration
-	experimentConfig.latencyLogger.printToLog();			// Print the latency logger config to log.txt								
+	// Get system configuration
+	systemConfig = SystemConfig::load(startupConfig.systemConfigFilename);
+	systemConfig.printToLog();			// Print the latency logger config to log.txt								
 
 	// Get the size of the primary display
 	displayRes = OSWindow::primaryDisplaySize();						
@@ -455,12 +456,12 @@ void FPSciApp::updateSession(const String& id) {
 		FileSystem::createDirectory(startupConfig.resultsDirPath);
 	}
 	const String logName = startupConfig.resultsDirPath + id + "_" + userStatusTable.currentUser + "_" + String(FPSciLogger::genFileTimestamp());
-	if (sessConfig->latencyLogger.hasLogger) {
+	if (systemConfig.hasLogger) {
 		if (!sessConfig->clickToPhoton.enabled) {
 			logPrintf("WARNING: Using a click-to-photon logger without the click-to-photon region enabled!\n\n");
 		}
 		if (m_pyLogger == nullptr) {
-			m_pyLogger = PythonLogger::create(sessConfig->latencyLogger.loggerComPort, sessConfig->latencyLogger.hasSync, sessConfig->latencyLogger.syncComPort);
+			m_pyLogger = PythonLogger::create(systemConfig.loggerComPort, systemConfig.hasSync, systemConfig.syncComPort);
 		}
 		else {
 			// Handle running logger if we need to (terminate then merge results)

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -130,7 +130,6 @@ public:
 	UserTable						userTable;						///< Table of per user information (DPI/cm/360) that doesn't change across experiment
 	UserStatusTable					userStatusTable;				///< Table of user status (session ordering/completed sessions) that do change across experiments
 	ExperimentConfig                experimentConfig;				///< Configuration for the experiment and its sessions
-	LatencyLoggerConfig				latencyLoggerConfig;			///< Configuration for the system/hardware
 	KeyMapping						keyMap;
 	shared_ptr<WaypointManager>		waypointManager;				///< Waypoint mananger pointer
 	

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -130,6 +130,7 @@ public:
 	UserTable						userTable;						///< Table of per user information (DPI/cm/360) that doesn't change across experiment
 	UserStatusTable					userStatusTable;				///< Table of user status (session ordering/completed sessions) that do change across experiments
 	ExperimentConfig                experimentConfig;				///< Configuration for the experiment and its sessions
+	SystemConfig					systemConfig;					///< System configuration
 	KeyMapping						keyMap;
 	shared_ptr<WaypointManager>		waypointManager;				///< Waypoint mananger pointer
 	

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -497,16 +497,16 @@ String Session::formatCommand(const String& input) {
 
 	while ((foundIdx = (int)formatted.find(delimiter, (size_t)foundIdx)) > -1) {
 		if (!formatted.compare(foundIdx, loggerComPort.length(), loggerComPort)) {
-			if (m_config->latencyLogger.loggerComPort.empty()) {
+			if (m_app->systemConfig.loggerComPort.empty()) {
 				throw "Found \"%loggerComPort\" substring in a command, but no \"loggerComPort\" is provided in the config!";
 			}
-			formatted = formatted.substr(0, foundIdx) + m_config->latencyLogger.loggerComPort + formatted.substr(foundIdx + loggerComPort.length());
+			formatted = formatted.substr(0, foundIdx) + m_app->systemConfig.loggerComPort + formatted.substr(foundIdx + loggerComPort.length());
 		}
 		else if (!formatted.compare(foundIdx, syncComPort.length(), syncComPort)) {
-			if (m_config->latencyLogger.syncComPort.empty()) {
+			if (m_app->systemConfig.syncComPort.empty()) {
 				throw "Found \"%loggerSyncComPort\" substring in a command, but no \"loggerSyncComPort\" is provided in the config!";
 			}
-			formatted = formatted.substr(0, foundIdx) + m_config->latencyLogger.syncComPort + formatted.substr(foundIdx + syncComPort.length());
+			formatted = formatted.substr(0, foundIdx) + m_app->systemConfig.syncComPort + formatted.substr(foundIdx + syncComPort.length());
 		}
 		else {
 			foundIdx++;

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -487,6 +487,34 @@ int Session::getScore() {
 	return (int)(10.0 * m_totalRemainingTime);
 }
 
+String Session::formatCommand(const String& input) {
+	const char delimiter = '%';			///< Start of all valid substrings
+	String formatted = input;			///< Output string
+	int foundIdx = 0;					///< Index for searching for substrings
+
+	const String loggerComPort = "%loggerComPort";
+	const String syncComPort = "%loggerSyncComPort";
+
+	while ((foundIdx = (int)formatted.find(delimiter, (size_t)foundIdx)) > -1) {
+		if (!formatted.compare(foundIdx, loggerComPort.length(), loggerComPort)) {
+			if (m_config->latencyLogger.loggerComPort.empty()) {
+				throw "Found \"%loggerComPort\" substring in a command, but no \"loggerComPort\" is provided in the config!";
+			}
+			formatted = formatted.substr(0, foundIdx) + m_config->latencyLogger.loggerComPort + formatted.substr(foundIdx + loggerComPort.length());
+		}
+		else if (!formatted.compare(foundIdx, syncComPort.length(), syncComPort)) {
+			if (m_config->latencyLogger.syncComPort.empty()) {
+				throw "Found \"%loggerSyncComPort\" substring in a command, but no \"loggerSyncComPort\" is provided in the config!";
+			}
+			formatted = formatted.substr(0, foundIdx) + m_config->latencyLogger.syncComPort + formatted.substr(foundIdx + syncComPort.length());
+		}
+		else {
+			foundIdx++;
+		}
+	}
+	return formatted;
+}
+
 String Session::formatFeedback(const String& input) {
 	const char delimiter = '%';			///< Start of all valid substrings
 	String formatted = input;			///< Output string

--- a/source/Session.h
+++ b/source/Session.h
@@ -197,6 +197,7 @@ protected:
 	}
 
 	String formatFeedback(const String& input);
+	String formatCommand(const String& input);
 
 	/** Insert a target into the target array/scene */
 	inline void insertTarget(shared_ptr<TargetEntity> target);
@@ -269,7 +270,8 @@ protected:
 		si.cb = sizeof(si);
 		ZeroMemory(&pi, sizeof(pi));
 
-		LPSTR command = LPSTR(cmd.c_str());
+		// Run the (formatted command)
+		LPSTR command = LPSTR(formatCommand(cmd).c_str());
 		if (!CreateProcess(NULL, command, NULL, NULL, TRUE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi)) {
 			logPrintf("Failed to run %s command: \"%s\". %s\n", evt, cmd, GetLastErrorString());
 		}


### PR DESCRIPTION
This branch removes the system config (renamed to `LatencyLoggerConfig` in code) in favor of uniting these parameters with the experiment config file. This has become the de-facto standard anyway as other loggers are now using commands specified in the `experimentconfig.Any` file rather than using the system config as intended.

It also adds support for replace-able substrings in commands, notably `%loggerComPort` and `%loggerSyncComPort` which now come from their affiliated input fields in the experiment config file.

Merging this PR closes #197.