### PR TITLE
Add clickToStart experiment config parameter

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -37,6 +37,7 @@ The following settings allow the user to control various timings/durations aroun
 
 | Parameter Name            |Units  | Description                                                        |
 |---------------------------|-------|--------------------------------------------------------------------|
+|`clickToStart`             |`bool` |Require the user to click at the start of the session to spawn the first reference target  |
 |`readyDuration`            |s      |The time before the start of each trial                             |
 |`taskDuration`             |s      |The maximum time over which the task can occur                      |
 |`feedbackDuration`         |s      |The duration of the feedback window between trials                  |
@@ -44,6 +45,7 @@ The following settings allow the user to control various timings/durations aroun
 |`scoreboardRequireClick`   |`bool` |Require the user to click to move past the scoreboard (in addition to waiting the `scoreboardDuration`)|
 
 ```
+"clickToStart : true,         // Require a click to start the session
 "readyDuration": 0.5,         // Time allocated for preparing for trial
 "taskDuration": 100000.0,     // Maximum duration allowed for completion of the task
 "feedbackDuration": 1.0,      // Time for user feedback between trials

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1477,6 +1477,7 @@ public:
 	float           taskDuration = 100000.0f;					///< Maximum time spent in any one task
 	float           feedbackDuration = 1.0f;					///< Time in feedback state in seconds
 	float			scoreboardDuration = 5.0f;					///< Time in scoreboard state in seconds
+	bool			clickToStart = true;						///< Require a click before starting the first session (spawning the reference target)
 	bool			scoreboardRequireClick = false;				///< Require a click to progress from the scoreboard?
 
 	// Trial count
@@ -1489,6 +1490,7 @@ public:
 			reader.getIfPresent("readyDuration", readyDuration);
 			reader.getIfPresent("taskDuration", taskDuration);
 			reader.getIfPresent("scoreboardDuration", scoreboardDuration);
+			reader.getIfPresent("clickToStart", clickToStart);
 			reader.getIfPresent("scoreboardRequireClick", scoreboardRequireClick);
 			reader.getIfPresent("defaultTrialCount", defaultTrialCount);
 			break;
@@ -1504,6 +1506,7 @@ public:
 		if(forceAll || def.readyDuration != readyDuration)				a["readyDuration"] = readyDuration;
 		if(forceAll || def.taskDuration != taskDuration)				a["taskDuration"] = taskDuration;
 		if(forceAll || def.scoreboardDuration != scoreboardDuration)	a["scoreboardDuration"] = scoreboardDuration;
+		if(forceAll || def.clickToStart != clickToStart)				a["clickToStart"] = clickToStart;
 		if(forceAll || def.scoreboardRequireClick != scoreboardRequireClick) a["scoreboardRequireClick"] = scoreboardRequireClick;
 		if(forceAll || def.defaultTrialCount != defaultTrialCount)		a["defaultTrialCount"] = defaultTrialCount;
 		return a;

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -245,8 +245,7 @@ void Session::updatePresentationState()
 		if (m_config->player.stillBetweenTrials) {
 			m_player->setMoveEnable(false);
 		}
-		if (!m_app->m_buttonUp)
-		{
+		if (!(m_app->m_buttonUp && m_config->timing.clickToStart)) {
 			newState = PresentationState::feedback;
 		}
 	}


### PR DESCRIPTION
This branch adds support for a `clickToStart` parameter (to be renamed?) that makes the first click (previously required to start a session) optional.