### PR TITLE
Prevents crash with no valid sessions

### DIFF
--- a/source/GuiElements.cpp
+++ b/source/GuiElements.cpp
@@ -607,8 +607,8 @@ void UserMenu::updateUserPress() {
 		m_lastUserIdx = m_ddCurrUserIdx;
 		
 		// Update (selected) sessions
-		String sessId = updateSessionDropDown()[0];
-		if (m_sessDropDown->numElements() > 0) m_app->updateSession(sessId);
+		const String sessId = updateSessionDropDown()[0];
+		m_app->updateSession(sessId);
 	}
 }
 

--- a/source/GuiElements.cpp
+++ b/source/GuiElements.cpp
@@ -587,6 +587,11 @@ Array<String> UserMenu::updateSessionDropDown() {
 		logPrintf("\t%s\n", id);
 	}
 
+	// Make sure there's an empty session in the list
+	if (remainingSess.size() == 0) {
+		remainingSess.append("");
+	}
+
 	return remainingSess;
 }
 

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -373,7 +373,7 @@ void Session::updatePresentationState()
 		else {
 			// Go ahead and move to the complete state since there aren't any valid sessions
 			newState = PresentationState::complete;
-			m_feedbackMessage = formatFeedback(m_config->feedback.allSessComplete);
+			m_feedbackMessage = formatFeedback("All sessions complete!");
 			moveOn = false;
 		}
 	}


### PR DESCRIPTION
Stops 2 crashes.

First is a crash when starting with no valid sessions for the selected user.

The second is a crash when switching to a user with no valid sessions. Unfortunately, this allows running the session that was selected for the user that still had valid sessions before switching to the user with no remaining sessions. It may be worth fixing this bug before merging. 