### PR TITLE
Removed unused ignore `x64`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .vscode
 .vs
 # Don't check in any compiled results
-vs/Build/x64
 vs/Build
 vs/packages
 # Avoid .pyc files (everywhere)


### PR DESCRIPTION
This accidentally got missed (because github fail) in #213 