### PR TITLE
Split/reuse updateTargetColor() for preview targets

### DIFF
--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -749,6 +749,7 @@ public:
 
 	ArticulatedModel::Specification modelSpec;							///< Model to use for the weapon (must be specified when renderModel=true)
 
+	/** Returns true if firePeriod == 0 and autoFire == true */
 	bool isLaser() {
 		return firePeriod == 0 && autoFire;
 	}

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -1133,7 +1133,7 @@ void FPSciApp::hitTarget(shared_ptr<TargetEntity> target) {
 	}
 }
 
-void FPSciApp::updateTargetColor(shared_ptr<TargetEntity>& target) {
+void FPSciApp::updateTargetColor(const shared_ptr<TargetEntity>& target) {
 	BEGIN_PROFILER_EVENT("updateTargetColor/changeColor");
 	BEGIN_PROFILER_EVENT("updateTargetColor/clone");
 	shared_ptr<ArticulatedModel::Pose> pose = dynamic_pointer_cast<ArticulatedModel::Pose>(target->pose()->clone());

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -1065,7 +1065,7 @@ void FPSciApp::hitTarget(shared_ptr<TargetEntity> target) {
 	// Check if we need to add combat text for this damage
 	if (sessConfig->targetView.showCombatText) {
 		m_combatTextList.append(FloatingCombatText::create(
-			format("%2.0f", 100 * damage),
+			format("%2.0f", 100.f * damage),
 			m_combatFont,
 			sessConfig->targetView.combatTextSize,
 			sessConfig->targetView.combatTextColor,
@@ -1133,16 +1133,16 @@ void FPSciApp::hitTarget(shared_ptr<TargetEntity> target) {
 	}
 }
 
-void FPSciApp::updateTargetColor(shared_ptr<TargetEntity> target) {
-	BEGIN_PROFILER_EVENT("fire/changeColor");
-	BEGIN_PROFILER_EVENT("fire/clone");
+void FPSciApp::updateTargetColor(shared_ptr<TargetEntity>& target) {
+	BEGIN_PROFILER_EVENT("updateTargetColor/changeColor");
+	BEGIN_PROFILER_EVENT("updateTargetColor/clone");
 	shared_ptr<ArticulatedModel::Pose> pose = dynamic_pointer_cast<ArticulatedModel::Pose>(target->pose()->clone());
 	END_PROFILER_EVENT();
-	BEGIN_PROFILER_EVENT("fire/materialSet");
+	BEGIN_PROFILER_EVENT("updateTargetColor/materialSet");
 	shared_ptr<UniversalMaterial> mat = m_materials[min((int)(target->health() * m_MatTableSize), m_MatTableSize - 1)];
 	pose->materialTable.set("core/icosahedron_default", mat);
 	END_PROFILER_EVENT();
-	BEGIN_PROFILER_EVENT("fire/setPose");
+	BEGIN_PROFILER_EVENT("updateTargetColor/setPose");
 	target->setPose(pose);
 	END_PROFILER_EVENT();
 	END_PROFILER_EVENT();

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -1232,9 +1232,9 @@ void FPSciApp::onUserInput(UserInput* ui) {
 						sess->accumulatePlayerAction(PlayerActionType::Invalid);
 					}
 				}
-			}
-			else {
-				sess->accumulatePlayerAction(PlayerActionType::Nontask); // not happening in task state.
+				else {
+					sess->accumulatePlayerAction(PlayerActionType::Nontask); // not happening in task state.
+				}
 			}
 
 			// Check for developer mode editing here, if so set selected waypoint using the camera

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -1128,19 +1128,24 @@ void FPSciApp::hitTarget(shared_ptr<TargetEntity> target) {
 		if (respawned) {
 			sess->randomizePosition(target);
 		}
-		BEGIN_PROFILER_EVENT("fire/changeColor");
-		BEGIN_PROFILER_EVENT("fire/clone");
-		shared_ptr<ArticulatedModel::Pose> pose = dynamic_pointer_cast<ArticulatedModel::Pose>(target->pose()->clone());
-		END_PROFILER_EVENT();
-		BEGIN_PROFILER_EVENT("fire/materialSet");
-		shared_ptr<UniversalMaterial> mat = m_materials[min((int)(target->health()*m_MatTableSize), m_MatTableSize - 1)];
-		pose->materialTable.set("core/icosahedron_default", mat);
-		END_PROFILER_EVENT();
-		BEGIN_PROFILER_EVENT("fire/setPose");
-		target->setPose(pose);
-		END_PROFILER_EVENT();
-		END_PROFILER_EVENT();
+		// Update the target color based on it's health
+		updateTargetColor(target);
 	}
+}
+
+void FPSciApp::updateTargetColor(shared_ptr<TargetEntity> target) {
+	BEGIN_PROFILER_EVENT("fire/changeColor");
+	BEGIN_PROFILER_EVENT("fire/clone");
+	shared_ptr<ArticulatedModel::Pose> pose = dynamic_pointer_cast<ArticulatedModel::Pose>(target->pose()->clone());
+	END_PROFILER_EVENT();
+	BEGIN_PROFILER_EVENT("fire/materialSet");
+	shared_ptr<UniversalMaterial> mat = m_materials[min((int)(target->health() * m_MatTableSize), m_MatTableSize - 1)];
+	pose->materialTable.set("core/icosahedron_default", mat);
+	END_PROFILER_EVENT();
+	BEGIN_PROFILER_EVENT("fire/setPose");
+	target->setPose(pose);
+	END_PROFILER_EVENT();
+	END_PROFILER_EVENT();
 }
 
 void FPSciApp::missEvent() {

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -182,7 +182,7 @@ public:
 	void markSessComplete(String id);
 	virtual void updateSession(const String& id);
 	void updateParameters(int frameDelay, float frameRate);
-	void updateTargetColor(shared_ptr<TargetEntity> target);
+	void updateTargetColor(shared_ptr<TargetEntity>& target);
 	void presentQuestion(Question question);
 
     void quitRequest();

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -99,7 +99,7 @@ protected:
 	/** Set the scoped view (and also adjust the turn scale), use setScopeView(!weapon->scoped()) to toggle scope */
 	void setScopeView(bool scoped = true);
 
-	void hitTarget(shared_ptr<TargetEntity>);
+	void hitTarget(shared_ptr<TargetEntity> target);
 	void missEvent();
 
 	virtual void drawHUD(RenderDevice *rd);
@@ -182,6 +182,7 @@ public:
 	void markSessComplete(String id);
 	virtual void updateSession(const String& id);
 	void updateParameters(int frameDelay, float frameRate);
+	void updateTargetColor(shared_ptr<TargetEntity> target);
 	void presentQuestion(Question question);
 
     void quitRequest();

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -182,7 +182,7 @@ public:
 	void markSessComplete(String id);
 	virtual void updateSession(const String& id);
 	void updateParameters(int frameDelay, float frameRate);
-	void updateTargetColor(shared_ptr<TargetEntity>& target);
+	void updateTargetColor(const shared_ptr<TargetEntity>& target);
 	void presentQuestion(Question question);
 
     void quitRequest();

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -140,10 +140,9 @@ void Session::initTargetAnimation() {
 	if (currentState == PresentationState::trialTask) {
 		if (m_config->targetView.previewWithRef && m_config->targetView.showRefTarget) {
 			// Activate the preview targets
-			const Color3 activeColor = m_config->targetView.healthColors[0];
 			for (shared_ptr<TargetEntity> target : m_targetArray) {
 				target->setCanHit(true);
-				target->setColor(activeColor);
+				m_app->updateTargetColor(target);
 				m_hittableTargets.append(target);
 			}
 		}

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -279,6 +279,9 @@ void Session::updatePresentationState()
 
 			closeTrialProcesses();				// Stop start of trial processes
 			runTrialCommands("end");			// Run the end of trial processes
+
+			// Reset weapon cooldown
+			m_lastFireAt = 0.f;
 		}
 	}
 	else if (currentState == PresentationState::trialFeedback)

--- a/source/TargetEntity.h
+++ b/source/TargetEntity.h
@@ -154,7 +154,7 @@ public:
 		}
 	}
 
-	/**Simple routine to do damage */
+	/**Apply damage to health and return true if health <= 0 */
 	bool doDamage(float damage) {
 		m_health -= damage;
 		return m_health <= 0;


### PR DESCRIPTION
This branch re-uses target materials (rather than creating new ones in `TargetEntity::setColor()` for activating targets). This should remove "activation artifacts" that might be caused by lengthy material allocation.

The concept is that the pre-created materials in the `FPSciApp::m_materials` array can be used to "activate" targets rather than creating a new one at runtime.

`TargetEntity::setColor()` is still used for spawning targets as this has not been reported as an issue in the past/is an easy way to create the preview material from within the `TargetEntity`.