### PR TITLE
Extend model scaling range w/ scale factor

### DIFF
--- a/data-files/test/experimentconfig.Any
+++ b/data-files/test/experimentconfig.Any
@@ -15,6 +15,7 @@
     playerGravity = Vector3(0,0,0);
 
 	showMenuOnStartup = false;
+    showMenuBetweenSessions = false;
 
     weapon = {
         id = "default"; 
@@ -32,6 +33,17 @@
                 {
                     ids = ( "keepalive", "front", "right" );
                     count = 10;
+                }
+            );
+        },
+        {
+            id = "sizes";
+            trials = (
+                {
+                    ids = ( "small", "medium", "large", "toosmall", "toolarge");
+                    //ids = ( "small");
+                    //ids = ( "small", "small", "small", "small", "small");
+                    count = 5;
                 }
             );
         }
@@ -91,6 +103,86 @@
             jumpEnabled = false;
             respawnCount = 0;
             axisLocked = [false,true,true];
+        },
+        {
+            id = "small";
+            speed = [ 0.0, 0.0 ];
+            visualSize = [ 0.05, 0.05 ];
+            destSpace = "world";
+            spawnBounds = AABox {
+                Point3(0.0, 0.0, -2.00001),
+                Point3(0.00001, 0.00001, -2.0),
+            };
+            moveBounds = AABox {
+                Point3(-100.0, -100.0, -100.0),
+                Point3(100.0, 100.0, 100.0),
+            };
+            motionChangePeriod = [ 0.8, 1.5 ];
+            jumpEnabled = false;
+        },
+        {
+            id = "medium";
+            speed = [ 0.0, 0.0 ];
+            visualSize = [ 0.1, 0.1 ];
+            destSpace = "world";
+            spawnBounds = AABox {
+                Point3(0.0, 0.0, -2.00001),
+                Point3(0.00001, 0.00001, -2.0),
+            };
+            moveBounds = AABox {
+                Point3(-100.0, -100.0, -100.0),
+                Point3(100.0, 100.0, 100.0),
+            };
+            motionChangePeriod = [ 0.8, 1.5 ];
+            jumpEnabled = false;
+        },
+        {
+            id = "large";
+            speed = [ 0.0, 0.0 ];
+            visualSize = [ 2, 2 ];
+            destSpace = "world";
+            spawnBounds = AABox {
+                Point3(0.0, 0.0, -2.00001),
+                Point3(0.00001, 0.00001, -2.0),
+            };
+            moveBounds = AABox {
+                Point3(-100.0, -100.0, -100.0),
+                Point3(100.0, 100.0, 100.0),
+            };
+            motionChangePeriod = [ 0.8, 1.5 ];
+            jumpEnabled = false;
+        },
+        {
+            id = "toosmall";
+            speed = [ 0.0, 0.0 ];
+            visualSize = [ 0.000001, 0.000001 ];
+            destSpace = "world";
+            spawnBounds = AABox {
+                Point3(0.0, 0.0, -2.00001),
+                Point3(0.00001, 0.00001, -2.0),
+            };
+            moveBounds = AABox {
+                Point3(-100.0, -100.0, -100.0),
+                Point3(100.0, 100.0, 100.0),
+            };
+            motionChangePeriod = [ 0.8, 1.5 ];
+            jumpEnabled = false;
+        },
+        {
+            id = "toolarge";
+            speed = [ 0.0, 0.0 ];
+            visualSize = [ 100000000, 100000000 ];
+            destSpace = "world";
+            spawnBounds = AABox {
+                Point3(0.0, 0.0, -2.00001),
+                Point3(0.00001, 0.00001, -2.0),
+            };
+            moveBounds = AABox {
+                Point3(-100.0, -100.0, -100.0),
+                Point3(100.0, 100.0, 100.0),
+            };
+            motionChangePeriod = [ 0.8, 1.5 ];
+            jumpEnabled = false;
         }
     );
 }

--- a/data-files/test/experimentconfig.Any
+++ b/data-files/test/experimentconfig.Any
@@ -169,14 +169,14 @@
         {
             id = "toolarge";
             speed = [ 0.0, 0.0 ];
-            visualSize = [ 100000000, 100000000 ];
+            visualSize = [ 200, 200 ];
             destSpace = "world";
             spawnBounds = AABox {
                 Point3(0.0, -2.0, -100.00001),
                 Point3(0.00001, -2.00001, -100.0),
             };
             moveBounds = AABox {
-                Point3(-100.0, -100.0, -100000000.0),
+                Point3(-100.0, -100.0, -200.0),
                 Point3(100.0, 100.0, 100.0),
             };
             motionChangePeriod = [ 0.8, 1.5 ];

--- a/data-files/test/experimentconfig.Any
+++ b/data-files/test/experimentconfig.Any
@@ -41,8 +41,6 @@
             trials = (
                 {
                     ids = ( "small", "medium", "large", "toosmall", "toolarge");
-                    //ids = ( "small");
-                    //ids = ( "small", "small", "small", "small", "small");
                     count = 5;
                 }
             );
@@ -110,8 +108,8 @@
             visualSize = [ 0.05, 0.05 ];
             destSpace = "world";
             spawnBounds = AABox {
-                Point3(0.0, 0.0, -2.00001),
-                Point3(0.00001, 0.00001, -2.0),
+                Point3(-0.5, 0.5, -1.00001),
+                Point3(-0.50001, 0.50001, -1.0),
             };
             moveBounds = AABox {
                 Point3(-100.0, -100.0, -100.0),
@@ -126,8 +124,8 @@
             visualSize = [ 0.1, 0.1 ];
             destSpace = "world";
             spawnBounds = AABox {
-                Point3(0.0, 0.0, -2.00001),
-                Point3(0.00001, 0.00001, -2.0),
+                Point3(0.0, 0.5, -1.00001),
+                Point3(0.00001, 0.50001, -1.0),
             };
             moveBounds = AABox {
                 Point3(-100.0, -100.0, -100.0),
@@ -142,8 +140,8 @@
             visualSize = [ 2, 2 ];
             destSpace = "world";
             spawnBounds = AABox {
-                Point3(0.0, 0.0, -2.00001),
-                Point3(0.00001, 0.00001, -2.0),
+                Point3(1.25, 0.5, -1.00001),
+                Point3(1.25001, 0.50001, -1.0),
             };
             moveBounds = AABox {
                 Point3(-100.0, -100.0, -100.0),
@@ -158,8 +156,8 @@
             visualSize = [ 0.000001, 0.000001 ];
             destSpace = "world";
             spawnBounds = AABox {
-                Point3(0.0, 0.0, -2.00001),
-                Point3(0.00001, 0.00001, -2.0),
+                Point3(0.02, -1.0, -0.00201),
+                Point3(0.02001, -1.00001, -0.002),
             };
             moveBounds = AABox {
                 Point3(-100.0, -100.0, -100.0),
@@ -174,11 +172,11 @@
             visualSize = [ 100000000, 100000000 ];
             destSpace = "world";
             spawnBounds = AABox {
-                Point3(0.0, 0.0, -2.00001),
-                Point3(0.00001, 0.00001, -2.0),
+                Point3(0.0, -2.0, -100.00001),
+                Point3(0.00001, -2.00001, -100.0),
             };
             moveBounds = AABox {
-                Point3(-100.0, -100.0, -100.0),
+                Point3(-100.0, -100.0, -100000000.0),
                 Point3(100.0, 100.0, 100.0),
             };
             motionChangePeriod = [ 0.8, 1.5 ];

--- a/data-files/test/userstatus.Any
+++ b/data-files/test/userstatus.Any
@@ -6,12 +6,12 @@
         { 
             completedSessions = ( ); 
             id = "TestUser"; 
-            sessions = ( "main"); 
+            sessions = ( "main", "sizes"); 
         }, 
         { 
             completedSessions = ( ); 
             id = "anon"; 
-            sessions = ( "main"); 
+            sessions = ( "main", "sizes"); 
         } ); 
     
 } 

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -187,7 +187,7 @@ void FPSciApp::loadModels() {
 
 		// Create the target/explosion models for this target
 		Array<shared_ptr<ArticulatedModel>> tModels, expModels;
-		for (int i = 0; i <= modelScaleCount; ++i) {
+		for (int i = 0; i <= TARGET_MODEL_SCALE_COUNT; ++i) {
 			const float scale = pow(1.0f + TARGET_MODEL_ARRAY_SCALING, float(i) - TARGET_MODEL_ARRAY_OFFSET);
 			tSpec.set("scale", scale*default_scale);
 			explosionSpec.set("scale", (20.0 * scale * explosionScales.get(id)));

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -138,7 +138,6 @@ public:
 	shared_ptr<DialogBase>			dialog;							///< Dialog box
 
 	Table<String, Array<shared_ptr<ArticulatedModel>>>	targetModels;
-	const int											modelScaleCount = 50;
 
 	shared_ptr<Session> sess;										///< Pointer to the experiment
 

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -138,7 +138,7 @@ public:
 	shared_ptr<DialogBase>			dialog;							///< Dialog box
 
 	Table<String, Array<shared_ptr<ArticulatedModel>>>	targetModels;
-	const int											modelScaleCount = 30;
+	const int											modelScaleCount = 50;
 
 	shared_ptr<Session> sess;										///< Pointer to the experiment
 

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -88,7 +88,6 @@ void Session::onInit(String filename, String description) {
 	m_camera = m_app->activeCamera();
 
 	m_targetModels = &(m_app->targetModels);
-	m_modelScaleCount = m_app->modelScaleCount;
 
 	// Check for valid session
 	if (m_hasSession) {
@@ -630,7 +629,7 @@ shared_ptr<TargetEntity> Session::spawnDestTarget(
 	// Create the target
 	const float targetSize = G3D::Random().common().uniform(config->size[0], config->size[1]);
 	const String nameStr = name.empty() ? format("target%03d", ++m_lastUniqueID) : name;
-	const int scaleIndex = clamp(iRound(log(targetSize) / log(1.0f + TARGET_MODEL_ARRAY_SCALING) + TARGET_MODEL_ARRAY_OFFSET), 0, m_modelScaleCount - 1);
+	const int scaleIndex = clamp(iRound(log(targetSize) / log(1.0f + TARGET_MODEL_ARRAY_SCALING) + TARGET_MODEL_ARRAY_OFFSET), 0, TARGET_MODEL_SCALE_COUNT - 1);
 
 	const shared_ptr<TargetEntity>& target = TargetEntity::create(config, nameStr, m_scene, (*m_targetModels)[config->id][scaleIndex], position, scaleIndex, paramIdx);
 
@@ -651,7 +650,7 @@ shared_ptr<FlyingEntity> Session::spawnReferenceTarget(
 	const float size,
 	const Color3& color)
 {
-	const int scaleIndex = clamp(iRound(log(size) / log(1.0f + TARGET_MODEL_ARRAY_SCALING) + TARGET_MODEL_ARRAY_OFFSET), 0, m_modelScaleCount - 1);
+	const int scaleIndex = clamp(iRound(log(size) / log(1.0f + TARGET_MODEL_ARRAY_SCALING) + TARGET_MODEL_ARRAY_OFFSET), 0, TARGET_MODEL_SCALE_COUNT - 1);
 	const shared_ptr<FlyingEntity>& target = FlyingEntity::create("reference", m_scene, (*m_targetModels)["reference"][scaleIndex], CFrame());
 
 	// Setup additional target parameters
@@ -672,7 +671,7 @@ shared_ptr<FlyingEntity> Session::spawnFlyingTarget(
 	const String& name)
 {
 	const float targetSize = G3D::Random().common().uniform(config->size[0], config->size[1]);
-	const int scaleIndex = clamp(iRound(log(targetSize) / log(1.0f + TARGET_MODEL_ARRAY_SCALING) + TARGET_MODEL_ARRAY_OFFSET), 0, m_modelScaleCount - 1);
+	const int scaleIndex = clamp(iRound(log(targetSize) / log(1.0f + TARGET_MODEL_ARRAY_SCALING) + TARGET_MODEL_ARRAY_OFFSET), 0, TARGET_MODEL_SCALE_COUNT - 1);
 	const String nameStr = name.empty() ? format("target%03d", ++m_lastUniqueID) : name;
 	const bool isWorldSpace = config->destSpace == "world";
 
@@ -702,7 +701,7 @@ shared_ptr<JumpingEntity> Session::spawnJumpingTarget(
 	const String& name)
 {
 	const float targetSize = G3D::Random().common().uniform(config->size[0], config->size[1]);
-	const int scaleIndex = clamp(iRound(log(targetSize) / log(1.0f + TARGET_MODEL_ARRAY_SCALING) + TARGET_MODEL_ARRAY_OFFSET), 0, m_modelScaleCount - 1);
+	const int scaleIndex = clamp(iRound(log(targetSize) / log(1.0f + TARGET_MODEL_ARRAY_SCALING) + TARGET_MODEL_ARRAY_OFFSET), 0, TARGET_MODEL_SCALE_COUNT - 1);
 	const String nameStr = name.empty() ? format("target%03d", ++m_lastUniqueID) : name;
 	const bool isWorldSpace = config->destSpace == "world";
 

--- a/source/Session.h
+++ b/source/Session.h
@@ -126,7 +126,6 @@ protected:
 
 	// Target management
 	Table<String, Array<shared_ptr<ArticulatedModel>>>* m_targetModels;
-	int m_modelScaleCount;
 	int m_lastUniqueID = 0;									///< Counter for creating unique names for various entities
 	
 	Array<shared_ptr<TargetEntity>> m_targetArray;			///< Array of drawn targets

--- a/source/TargetEntity.h
+++ b/source/TargetEntity.h
@@ -7,9 +7,10 @@ class TargetConfig;
 //#define DRAW_BOUNDING_SPHERES	1		// Uncomment this to draw bounding spheres (useful for target sizing)
 #define BOUNDING_SPHERE_RADIUS	0.5		///< Use a 0.5m radius for sizing here
 
-// Scale and offset for target
+// Scale, offset and count for target scaling
 const float TARGET_MODEL_ARRAY_SCALING = 0.25992104989f;
 const float TARGET_MODEL_ARRAY_OFFSET = 40;
+const int	TARGET_MODEL_SCALE_COUNT = 50;
 
 struct Destination{
 public:

--- a/source/TargetEntity.h
+++ b/source/TargetEntity.h
@@ -8,7 +8,7 @@ class TargetConfig;
 #define BOUNDING_SPHERE_RADIUS	0.5		///< Use a 0.5m radius for sizing here
 
 // Scale and offset for target
-const float TARGET_MODEL_ARRAY_SCALING = 0.2f;
+const float TARGET_MODEL_ARRAY_SCALING = 0.4f;
 const float TARGET_MODEL_ARRAY_OFFSET = 20;
 
 struct Destination{

--- a/source/TargetEntity.h
+++ b/source/TargetEntity.h
@@ -8,8 +8,8 @@ class TargetConfig;
 #define BOUNDING_SPHERE_RADIUS	0.5		///< Use a 0.5m radius for sizing here
 
 // Scale and offset for target
-const float TARGET_MODEL_ARRAY_SCALING = 0.4f;
-const float TARGET_MODEL_ARRAY_OFFSET = 20;
+const float TARGET_MODEL_ARRAY_SCALING = 0.25992104989f;
+const float TARGET_MODEL_ARRAY_OFFSET = 40;
 
 struct Destination{
 public:

--- a/source/TargetEntity.h
+++ b/source/TargetEntity.h
@@ -7,10 +7,12 @@ class TargetConfig;
 //#define DRAW_BOUNDING_SPHERES	1		// Uncomment this to draw bounding spheres (useful for target sizing)
 #define BOUNDING_SPHERE_RADIUS	0.5		///< Use a 0.5m radius for sizing here
 
-// Scale, offset and count for target scaling
-const float TARGET_MODEL_ARRAY_SCALING = 0.25992104989f;
-const float TARGET_MODEL_ARRAY_OFFSET = 40;
-const int	TARGET_MODEL_SCALE_COUNT = 50;
+// 1 - 2 ^ (1/3) makes multiples of 2 regular
+#define TARGET_MODEL_ARRAY_SCALING 0.25992104989f
+// Model size offset
+#define TARGET_MODEL_ARRAY_OFFSET 40.0f
+// Number of target model sizes
+#define TARGET_MODEL_SCALE_COUNT 50
 
 struct Destination{
 public:

--- a/source/WaypointManager.cpp
+++ b/source/WaypointManager.cpp
@@ -193,7 +193,7 @@ shared_ptr<TargetEntity> WaypointManager::spawnDestTargetPreview(
 {
 	// Create the target
 	const String nameStr = name.empty() ? format("destPreview") : name;
-	const int scaleIndex = clamp(iRound(log(size) / log(1.0f + TARGET_MODEL_ARRAY_SCALING) + TARGET_MODEL_ARRAY_OFFSET), 0, m_app->modelScaleCount - 1);
+	const int scaleIndex = clamp(iRound(log(size) / log(1.0f + TARGET_MODEL_ARRAY_SCALING) + TARGET_MODEL_ARRAY_OFFSET), 0, TARGET_MODEL_SCALE_COUNT - 1);
 	const shared_ptr<TargetEntity>& target = TargetEntity::create(dests, nameStr, m_scene, m_app->targetModels[id][scaleIndex], scaleIndex, 0);
 
 	// Setup (additional) target parameters

--- a/tests/FPSciTests.cpp
+++ b/tests/FPSciTests.cpp
@@ -500,8 +500,8 @@ TEST_F(FPSciTests, TestAutoFire) {
 TEST_F(FPSciTests, TestTargetSizes) {
 	SelectSession("sizes");
 
-	// epsilon for size comparisons
-	float e = 0.00001f;
+	// % error for size comparisons
+	float e = 0.035f;
 
 	s_app->oneFrame();
 	auto spawnedtargets = respawnTargets();
@@ -518,30 +518,30 @@ TEST_F(FPSciTests, TestTargetSizes) {
 	auto smallid = small->id();
 	EXPECT_TRUE(smallid.compare("small") == 0);
 	auto smallsize = small->size();
-	float targetsmallsize = 0.05408785f;
+	float targetsmallsize = 0.05f;
 	EXPECT_NEAR(smallsize, targetsmallsize, targetsmallsize * e);
 
 	auto mediumid = medium->id();
 	EXPECT_TRUE(mediumid.compare("medium") == 0);
 	auto mediumsize = medium->size();
-	float targetmediumsize = 0.09346383f;
+	float targetmediumsize = 0.1f;
 	EXPECT_NEAR(mediumsize, targetmediumsize, targetmediumsize * e);
 
 	auto largeid = large->id();
 	EXPECT_TRUE(largeid.compare("large") == 0);
 	auto largesize = large->size();
-	float targetlargesize = 2.07360029f;
+	float targetlargesize = 2.0f;
 	EXPECT_NEAR(largesize, targetlargesize, targetlargesize * e);
 
 	auto toosmallid = toosmall->id();
 	EXPECT_TRUE(toosmallid.compare("toosmall") == 0);
 	auto toosmallsize = toosmall->size();
-	float targettoosmallsize = 0.02608403f;
+	float targettoosmallsize = 0.0001f;
 	EXPECT_NEAR(toosmallsize, targettoosmallsize, targettoosmallsize * e);
 
 	auto toolargeid = toolarge->id();
 	EXPECT_TRUE(toolargeid.compare("toolarge") == 0);
 	auto toolargesize = toolarge ->size();
-	float targettoolargesize = 5.15978241f;
+	float targettoolargesize = 8.0f;
 	EXPECT_NEAR(toolargesize, targettoolargesize, targettoolargesize * e);
 }

--- a/tests/FPSciTests.cpp
+++ b/tests/FPSciTests.cpp
@@ -513,8 +513,7 @@ TEST_F(FPSciTests, TestTargetSizes) {
 	auto toosmall = s_app->sess->targetArray()[3];
 	auto toolarge = s_app->sess->targetArray()[4];
 
-	// All of the below sizes are what is computed in TargetEntity.h and 
-	// *do not match* the values written in the config
+	// Expect to match the values written in the config
 	auto smallid = small->id();
 	EXPECT_TRUE(smallid.compare("small") == 0);
 	auto smallsize = small->size();
@@ -536,12 +535,14 @@ TEST_F(FPSciTests, TestTargetSizes) {
 	auto toosmallid = toosmall->id();
 	EXPECT_TRUE(toosmallid.compare("toosmall") == 0);
 	auto toosmallsize = toosmall->size();
+	// smallest target is 0.1 mm
 	float targettoosmallsize = 0.0001f;
 	EXPECT_NEAR(toosmallsize, targettoosmallsize, targettoosmallsize * e);
 
 	auto toolargeid = toolarge->id();
 	EXPECT_TRUE(toolargeid.compare("toolarge") == 0);
 	auto toolargesize = toolarge ->size();
+	// largest target is 8 m
 	float targettoolargesize = 8.0f;
 	EXPECT_NEAR(toolargesize, targettoolargesize, targettoolargesize * e);
 }

--- a/tests/FPSciTests.h
+++ b/tests/FPSciTests.h
@@ -24,6 +24,8 @@ protected:
 	static void SetUpTestSuite();
 	/** Setup the suite for all tests (FPSci specific) */
 	static void SetUpTestSuiteSafe();
+	/** Setup a new session with the provided id*/
+	static void SelectSession(const String& id);
 	/** Teardown the suite for all tests */
 	static void TearDownTestSuite();
 	/** Setup and individual test case (setup the test suite) */


### PR DESCRIPTION
This branch changes the `TARGET_MODEL_ARRAY_SCALING` macro in code to extend the range of the model scaling at some limited cost to scale granularity.

FPSci implements model sizing by:

1. Sizing the model to 1m with a "default" scale factor
2. Applying an additional logarithmic scale following: 
```scale = (1 + TARGET_MODEL_ARRAY_SCALING) ^ (i - TARGET_MODEL_ARRAY_OFFSET)```
where `i` is the index within the array (in the range `[0, Target array length - 1]`)

The "fix" here is to keep the target model array the same size, but increase the `TARGET_MODEL_ARRAY_SCALING` (slightly) to increase the range of target sizes that can be created from within the application. This allows a wider range of target scales to be represented (at lower granularity).

Specifically the request from @joohwankimNV was to make smaller player-space targets (typically the smallest targets as they tend to be located the closest to the user).

The original values were:
* `TARGET_MODEL_ARRAY_SCALING` = 0.2
* `TARGET_MODEL_ARRAY_OFFSET` = 20
* Target array length = 30

This meant that the minimum representable target size was given by: `1.2 ^ -20` and corresponds to a target about 0.025m in size. By changing the `TARGET_MODEL_ARRAY_SCALING` to `0.4` we now get a minimum target size of `1.4 ^ -20` or about 0.001m (should be smaller than a pixel at the default view distance on a 1080p monitor).  This represents a minimum target size reduction of 25x. Similarly the max target size increases from about 5m to about 20m. 

The corresponding effect is a drop in the "granularity" of target size, which is dependent on the target size in question. For our most common player-space target sizes (0.01-0.05m) there are still 5 valid target sizes. This should be tested to make sure the granularity is sufficient. If not we can always increase the target array size instead of just changing scaling.