### PR TITLE
Lower audio latency (requires G3D r7012 or newer)

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -19,9 +19,11 @@ int main(int argc, const char* argv[]) {
 		G3DSpecification spec;
 		spec.audio = FPSciApp::startupConfig.audioEnable;
 		
-		// lower audio latency
+		// lower audio latency to 256 / 48000 * 1000 * (3 - 1.5) = 8 ms
+		// Based on Average latency (ms) = bufferlength / 48kHz * 1000ms/s * (numbuffers - 1.5)
+		// See more here: https://github.com/NVlabs/abstract-fps/pull/223
 		spec.audioBufferLength = 256;
-		spec.audioNumBuffers = 1;
+		spec.audioNumBuffers = 3;
 
 		initGLG3D(spec);
 	}

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -18,6 +18,11 @@ int main(int argc, const char* argv[]) {
 	{
 		G3DSpecification spec;
 		spec.audio = FPSciApp::startupConfig.audioEnable;
+		
+		// lower audio latency
+		spec.audioBufferLength = 256;
+		spec.audioNumBuffers = 1;
+
 		initGLG3D(spec);
 	}
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -40,6 +40,11 @@ int main(int argc, const char** argv)
 		{
 			G3DSpecification spec;
 			spec.audio = FPSciApp::startupConfig.audioEnable;
+			// lower audio latency to 256 / 48000 * 1000 * (3 - 1.5) = 8 ms
+			// Based on Average latency (ms) = bufferlength / 48kHz * 1000ms/s * (numbuffers - 1.5)
+			// See more here: https://github.com/NVlabs/abstract-fps/pull/223
+			spec.audioBufferLength = 256;
+			spec.audioNumBuffers = 3;
 			initGLG3D(spec);
 		}
 		g_defaultSettings = std::make_unique<FPSciApp::Settings>(FPSciApp::startupConfig, 1, argv);


### PR DESCRIPTION
This pull request taps into the newly exposed G3D ability to control the DSP buffer size, which affects the audio latency. At the moment, it's unclear what cost these changes have, so I'm opening this pull request up with the intent to test it.

The smaller buffer sizes proposed to reduce latency, but at the cost of increase CPU utilization, which I haven't yet characterized. We need to examine how much that cost is to decide whether it's worth paying, or if we want a less (or more) aggressive setting.