### PR TITLE
Allow developers to reload their configs from disk while running

### DIFF
--- a/docs/developermode.md
+++ b/docs/developermode.md
@@ -16,6 +16,7 @@ Features include:
 * Dynamic brightness (exposure) control
 * Waypoint-based [target path creation](./patheditor.md)
 * Initialization of player position and view direction
+* Dynamic config reload in app via the `reloadConfigs` mapped key
 
 ## Enabling Developer Mode
 As mentioned above, all that needs to be done to enabled developer mode is modifying the `developerMode` field in [`startupconfig.Any`](../data-files/startupconfig.Any) to `True`, then running the application to enter developer mode.

--- a/docs/keymap.md
+++ b/docs/keymap.md
@@ -37,6 +37,7 @@ When `developerMode=true` the following keys/actions are available in addition t
 |`End`      |Move waypoint out in space         |
 |`Insert`   |Move waypoint right in space       |
 |`Delete`   |Move waypoint left in space        |
+|`F5`       |Reload all configs from disk       |
 
 ## Custom Key Mappings
 As an alternative to the standard key mappings provided above the user can change/add buttons to any of these actions using a `keymap.Any` file. If no `keymap.Any` file exists when the application starts it will write out the default.
@@ -69,6 +70,7 @@ This file associates each of the map names outlined below to an array of `GKey` 
 |Move waypoint out in space         |`moveWaypointOut`      |`["End"]`              |
 |Move waypoint right in space       |`moveWaypointRight`    |`["Ins"]`              |
 |Move waypoint left in space        |`moveWaypointLeft`     |`["Del"]`              |
+|Reload config (developer mode)     |`reloadConfigs`        |`["F5"]`               |
 
 ### GKey Strings
 The table below provides some useful macros for mapping `String` --> `GKey`. Whenever you are referring to a "normal" character key, be sure to use upper case letters!

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -124,6 +124,7 @@ public:
 		map.set("moveWaypointOut", Array<GKey>{ GKey::END });
 		map.set("moveWaypointRight", Array<GKey>{ GKey::INSERT });
 		map.set("moveWaypointLeft", Array<GKey>{ GKey::DELETE });
+		map.set("reloadConfigs", Array<GKey>{GKey::F5});
 		getUiKeyMapping();
 	};
 

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -693,10 +693,9 @@ bool FPSciApp::onEvent(const GEvent& event) {
 			else if (keyMap.map["reloadConfigs"].contains(ksym)) {
 				loadConfigs();												// (Re)load the configs
 				// Update session from the reloaded configs
-				updateMouseSensitivity();									// Update (apply) mouse sensitivity
-				m_userSettingsWindow->updateSessionDropDown();				// Update the session drop down to remove already completed sessions
-				updateSession(m_userSettingsWindow->selectedSession());		// Update session to create results file/start collection
-				// Pass the key stroke on to onEvent() for now?
+				m_userSettingsWindow->updateSessionDropDown();
+				updateSession(m_userSettingsWindow->selectedSession());
+				// Do not set foundKey = true to allow shader reloading from GApp::onEvent()
 			}
 			// Waypoint editor only keys
 			else if (startupConfig.waypointEditorMode) {

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -239,19 +239,21 @@ void FPSciApp::updateControls(bool firstSession) {
 }
 
 void FPSciApp::makeGUI() {
-	debugWindow->setVisible(startupConfig.developerMode);
-	developerWindow->setVisible(startupConfig.developerMode);
-	developerWindow->cameraControlWindow->setVisible(startupConfig.developerMode);
-	developerWindow->videoRecordDialog->setEnabled(true);
-	developerWindow->videoRecordDialog->setCaptureGui(true);
 
 	theme = GuiTheme::fromFile(System::findDataFile("osx-10.7.gtm"));
+	debugWindow->setVisible(startupConfig.developerMode);
 
-	// Update the scene editor (for new PhysicsScene pointer, initially loaded in GApp)
-	removeWidget(developerWindow->sceneEditorWindow);
-	developerWindow->sceneEditorWindow = SceneEditorWindow::create(this, scene(), theme);
-	developerWindow->sceneEditorWindow->moveTo(developerWindow->cameraControlWindow->rect().x0y1() + Vector2(0, 15));
-	developerWindow->sceneEditorWindow->setVisible(startupConfig.developerMode);
+	if (startupConfig.developerMode) {
+		developerWindow->cameraControlWindow->setVisible(startupConfig.developerMode);
+		developerWindow->videoRecordDialog->setEnabled(true);
+		developerWindow->videoRecordDialog->setCaptureGui(true);
+
+		// Update the scene editor (for new PhysicsScene pointer, initially loaded in GApp)
+		removeWidget(developerWindow->sceneEditorWindow);
+		developerWindow->sceneEditorWindow = SceneEditorWindow::create(this, scene(), theme);
+		developerWindow->sceneEditorWindow->moveTo(developerWindow->cameraControlWindow->rect().x0y1() + Vector2(0, 15));
+		developerWindow->sceneEditorWindow->setVisible(startupConfig.developerMode);
+	}
 
 	// Open sub-window buttons here (menu-style)
 	debugPane->beginRow(); {
@@ -1625,6 +1627,8 @@ FPSciApp::Settings::Settings(const StartupConfig& startupConfig, int argc, const
 	window.caption = "First Person Science";
 	window.refreshRate = -1;
 	window.defaultIconFilename = "icon.png";
+
+	useDeveloperTools = startupConfig.developerMode;
 
 	hdrFramebuffer.depthGuardBandThickness = Vector2int16(64, 64);
 	hdrFramebuffer.colorGuardBandThickness = Vector2int16(0, 0);

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -767,6 +767,15 @@ bool FPSciApp::onEvent(const GEvent& event) {
 			}
 		}
 	}
+	// Handle key strokes explicitly for non-developer mode
+	else {
+		if (event.type == GEventType::KEY_DOWN) {
+			const Array<GKey> player_masked = { GKey::F8 };
+			if (player_masked.contains(ksym)) {
+				foundKey = true;
+			}
+		}
+	}
 	
 	// Handle normal keypresses
 	if (event.type == GEventType::KEY_DOWN) {
@@ -782,7 +791,7 @@ bool FPSciApp::onEvent(const GEvent& event) {
 			// Override 'q', 'z', 'c', and 'e' keys (unused)
 			// Remove F8 as it isn't masked by useDeveloperTools = False
 			// THIS IS A PROBLEM IF THESE ARE KEY MAPPED!!!
-			const Array<GKey> unused = { (GKey)'e', (GKey)'z', (GKey)'c', (GKey)'q', GKey::F8 };
+			const Array<GKey> unused = { (GKey)'e', (GKey)'z', (GKey)'c', (GKey)'q'};
 			if (unused.contains(ksym)) {
 				foundKey = true;
 			}

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -770,6 +770,7 @@ bool FPSciApp::onEvent(const GEvent& event) {
 	// Handle key strokes explicitly for non-developer mode
 	else {
 		if (event.type == GEventType::KEY_DOWN) {
+			// Remove F8 as it isn't masked by useDeveloperTools = False
 			const Array<GKey> player_masked = { GKey::F8 };
 			if (player_masked.contains(ksym)) {
 				foundKey = true;
@@ -789,9 +790,8 @@ bool FPSciApp::onEvent(const GEvent& event) {
 		}
 		else if (activeCamera() == playerCamera) {
 			// Override 'q', 'z', 'c', and 'e' keys (unused)
-			// Remove F8 as it isn't masked by useDeveloperTools = False
 			// THIS IS A PROBLEM IF THESE ARE KEY MAPPED!!!
-			const Array<GKey> unused = { (GKey)'e', (GKey)'z', (GKey)'c', (GKey)'q'};
+			const Array<GKey> unused = { (GKey)'e', (GKey)'z', (GKey)'c', (GKey)'q' };
 			if (unused.contains(ksym)) {
 				foundKey = true;
 			}

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -779,9 +779,10 @@ bool FPSciApp::onEvent(const GEvent& event) {
 			return true;
 		}
 		else if (activeCamera() == playerCamera) {
-			// Override 'q', 'z', 'c', and 'e' keys (unused) 
+			// Override 'q', 'z', 'c', and 'e' keys (unused)
+			// Remove F8 as it isn't masked by useDeveloperTools = False
 			// THIS IS A PROBLEM IF THESE ARE KEY MAPPED!!!
-			const Array<GKey> unused = { (GKey)'e', (GKey)'z', (GKey)'c', (GKey)'q' };
+			const Array<GKey> unused = { (GKey)'e', (GKey)'z', (GKey)'c', (GKey)'q', GKey::F8 };
 			if (unused.contains(ksym)) {
 				foundKey = true;
 			}

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -83,7 +83,8 @@ protected:
 	void updateControls(bool firstSession = false);
 	void loadConfigs();
 	virtual void loadModels();
-	/** Initializes player settings from configs and resets player to initial position */
+	/** Initializes player settings from configs and resets player to initial position 
+		Also updates mouse sensitivity. */
 	void initPlayer();
 
 	/** Move a window to the center of the display */
@@ -179,6 +180,7 @@ public:
 	shared_ptr<UserConfig> const currentUser(void) {  return userTable.getUserById(userStatusTable.currentUser); }
 
 	void markSessComplete(String id);
+	/** Updates experiment state to the provided session id and updates player parameters (including mouse sensitivity) */
 	virtual void updateSession(const String& id);
 	void updateParameters(int frameDelay, float frameRate);
 	void updateTargetColor(const shared_ptr<TargetEntity>& target);

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -81,6 +81,7 @@ protected:
 	/** Called from onInit */
 	void makeGUI();
 	void updateControls(bool firstSession = false);
+	void loadConfigs();
 	virtual void loadModels();
 	/** Initializes player settings from configs and resets player to initial position */
 	void initPlayer();

--- a/source/GuiElements.h
+++ b/source/GuiElements.h
@@ -145,6 +145,7 @@ public:
 	}
 
 	void setVisible(bool visibile);
+	/** Resets session drop down clearing completed sessions and adding any new sessions. */
 	Array<String> updateSessionDropDown();
 	void updateReticlePreview();
 


### PR DESCRIPTION
This branch adds support for a new `reloadConfigs` key within the key map. When `developerMode=true` in the startup config, this allows developers to reload configs from within the application without restarting. By default this key is set to `F5` to coincide with the generic reload offered by G3D.

Merging this PR closes #127 