### PR TITLE
dbFilename command substring support

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -543,10 +543,11 @@ commandsOnSessionEnd = ( { command = "cmd /c start [webpage URL]", foreground = 
 ### Supported Substrings for Commands
 In addition to the basic commands provided above several replacable substrings are supported in commands. These include:
 
-| Substring         | Description                                                           |
-|-------------------|-----------------------------------------------------------------------|
-|`%loggerComPort`   | The logger COM port (optionally) provided in a general config         |
-|`%loggerSyncComPort`|  The logger sync COM port (optionally) provided in a general config  |
+| Substring             | Description                                                           |
+|-----------------------|-----------------------------------------------------------------------|
+|`%loggerComPort`       | The logger COM port (optionally) provided in a general config         |
+|`%loggerSyncComPort`   |  The logger sync COM port (optionally) provided in a general config   |
+|`%dbFilename`          | The filename of the created db file (less the `.db` extension)        |
 
 Note that if either of these substrings is specified in a command, but empty/not provided in the experiment config file an exception will be thrown.
 

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -947,10 +947,10 @@ void FPSciApp::drawClickIndicator(RenderDevice *rd, String mode) {
 		// Draw the "active" box
 		Color3 boxColor;
 		if (sessConfig->clickToPhoton.mode == "frameRate") {
-			boxColor = (m_frameToggle) ? sessConfig->clickToPhoton.colors[0] : sessConfig->clickToPhoton.colors[1];
-			m_frameToggle = !m_frameToggle;
+			boxColor = (frameToggle) ? sessConfig->clickToPhoton.colors[0] : sessConfig->clickToPhoton.colors[1];
+			frameToggle = !frameToggle;
 		}
-		else boxColor = (m_buttonUp) ? sessConfig->clickToPhoton.colors[0] : sessConfig->clickToPhoton.colors[1];
+		else boxColor = (buttonUp) ? sessConfig->clickToPhoton.colors[0] : sessConfig->clickToPhoton.colors[1];
 		Draw::rect2D(Rect2D::xywh(boxLeft, boxTop, latencyRect.x, latencyRect.y), rd, boxColor);
 	}
 }
@@ -1226,7 +1226,7 @@ void FPSciApp::onUserInput(UserInput* ui) {
 	for (GKey shootButton : keyMap.map["shoot"]) {
 		// Require release between clicks for non-autoFire modes
 		if (ui->keyReleased(shootButton)) {
-			m_buttonUp = true;
+			buttonUp = true;
 			haveReleased = true;
 			m_weapon->setFiring(false);
 			if (!sessConfig->weapon.autoFire) {
@@ -1277,7 +1277,7 @@ void FPSciApp::onUserInput(UserInput* ui) {
 			}
 
 			haveReleased = false;					// Make it known we are no longer in released state
-			m_buttonUp = false;
+			buttonUp = false;
 		}
 	}
 	

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -139,14 +139,17 @@ public:
 
 	Table<String, Array<shared_ptr<ArticulatedModel>>>	targetModels;
 
-	shared_ptr<Session> sess;			///< Pointer to the experiment
-	shared_ptr<Camera> playerCamera;	///< Pointer to the player camera						
+	shared_ptr<Session> sess;					///< Pointer to the experiment
+	shared_ptr<Camera> playerCamera;			///< Pointer to the player camera						
 
-	bool renderFPS = false;				///< Control flag used to draw (or not draw) FPS information to the display	
-	int  displayLagFrames = 0;			///< Count of frames of latency to add
-	float lastSetFrameRate = 0.0f;		///< Last set frame rate
-	const int numReticles = 55;			///< Total count of reticles available to choose from
-	float sceneBrightness = 1.0f;		///< Scene brightness scale factor
+	bool		renderFPS			= false;	///< Control flag used to draw (or not draw) FPS information to the display	
+	int			displayLagFrames	= 0;		///< Count of frames of latency to add
+	float		lastSetFrameRate	= 0.0f;		///< Last set frame rate
+	const int	numReticles			= 55;		///< Total count of reticles available to choose from
+	float		sceneBrightness		= 1.0f;		///< Scene brightness scale factor
+
+	bool		buttonUp			= true;		///< Pass button up to session
+	bool		frameToggle			= false;	///< Simple toggle flag used for frame rate click-to-photon monitoring
 
 	Vector2 displayRes;
 
@@ -213,8 +216,6 @@ public:
 	virtual void onCleanup() override;
     virtual void oneFrame() override;
 
-	bool							m_buttonUp = true;
-	bool							m_frameToggle = false;		///< Simple toggle flag used for frame rate click-to-photon monitoring
 };
 
 // The "old" way of animation

--- a/source/Session.h
+++ b/source/Session.h
@@ -111,7 +111,10 @@ protected:
 	Scene* m_scene = nullptr;							///< Pointer to the scene
 	
 	shared_ptr<SessionConfig> m_config;					///< The session this experiment will run
+	
 	shared_ptr<FPSciLogger> m_logger;					///< Output results logger
+	String m_dbFilename;								///< Filename for output logging (less the .db extension)
+
 	shared_ptr<PlayerEntity> m_player;					///< Player entity
 	shared_ptr<Camera> m_camera;						///< Camera entity
 


### PR DESCRIPTION
This branch adds support for a `%dbFilename` sub-string that can be used in commands to reference the db file currently being written to. The substring does not include the `.db` extension so users can refer to other file types by this name as well.

This should be useful in getting correspondence between logs produced by FPSci and logs output from other logging utilities where the output filename can be specified within the command that calls the logger.