### PR TITLE
Feedback message color

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -75,7 +75,18 @@ The following settings allow the user to control various timings/durations aroun
 ```
 
 ## Feedback Configuration
-In addition to controlling the duration of displayed feedback messages, this configuration allows the experiment designer to control the messages provided as feedback themselves.
+
+### Feedback Formatting
+The formatting of feedback messages is controllable from general config, included formatting parameters include:
+
+| Parameter Name                    |Units      | Description                                                           |
+|-----------------------------------|-----------|-----------------------------------------------------------------------|
+|`feedbackColor`                    |`Color3`   | The text color to use for the feedback message                        |
+|`feedbackOutlineColor`             |`Color4`   | The text outline color to use for the feedback message                |
+|`feedbackFontSize`                 |`float`    | The font size to use for the feedback message (scales w/ window)      |
+
+### Feedback Messages
+In addition to controlling the duration and formatting of displayed feedback messages, this configuration allows the experiment designer to control the messages provided as feedback themselves.
 
 | Parameter Name                    |Units    | Description                                                        |
 |-----------------------------------|---------|--------------------------------------------------------------------|
@@ -86,6 +97,7 @@ In addition to controlling the duration of displayed feedback messages, this con
 |`blockCompleteFeedback`            |`String` | Message to display when a block is completed                       |
 |`sessionCompleteFeedback`          |`String` | Message to display when a session is completed                     |
 |`allSessionsCompleteFeedback`      |`String` | Message to display when all sessions are completed                 |
+
 
 For any/all of the feedback strings provided above, a number of `%`-delimited special strings are supported to allow find-and-replace with certain values. These include:
 

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -84,6 +84,7 @@ The formatting of feedback messages is controllable from general config, include
 |`feedbackColor`                    |`Color3`   | The text color to use for the feedback message                        |
 |`feedbackOutlineColor`             |`Color4`   | The text outline color to use for the feedback message                |
 |`feedbackFontSize`                 |`float`    | The font size to use for the feedback message (scales w/ window)      |
+|`feedbackBackgroundColor`          |`Color4`   | The "back plate" color to apply to the feedback message (use clear for no plate) |
 
 ### Feedback Messages
 In addition to controlling the duration and formatting of displayed feedback messages, this configuration allows the experiment designer to control the messages provided as feedback themselves.

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -75,16 +75,24 @@ The following settings allow the user to control various timings/durations aroun
 ```
 
 ## Feedback Configuration
+In addition to the trial/session feedback duration control, the formatting and strings used for feedback are also configurable.
 
 ### Feedback Formatting
 The formatting of feedback messages is controllable from general config, included formatting parameters include:
 
 | Parameter Name                    |Units      | Description                                                           |
 |-----------------------------------|-----------|-----------------------------------------------------------------------|
+|`feedbackFontSize`                 |`float`    | The font size to use for the feedback message (scales w/ window)      |
 |`feedbackColor`                    |`Color3`   | The text color to use for the feedback message                        |
 |`feedbackOutlineColor`             |`Color4`   | The text outline color to use for the feedback message                |
-|`feedbackFontSize`                 |`float`    | The font size to use for the feedback message (scales w/ window)      |
 |`feedbackBackgroundColor`          |`Color4`   | The "back plate" color to apply to the feedback message (use clear for no plate) |
+
+```
+feedbackFontSize = 20;                          // Feedback font size of 20
+feedbackColor = Color3(0.648, 1.0, 0);          // Feedback text foreground color
+feedbackOutlineColor = Color4(0,0,0,0);         // Transparent feedback text outline
+feedbackBackgroundColor = Color4(0,0,0,0.5);    // Semi-transparent back plate
+```
 
 ### Feedback Messages
 In addition to controlling the duration and formatting of displayed feedback messages, this configuration allows the experiment designer to control the messages provided as feedback themselves.

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1606,10 +1606,11 @@ public:
 	String sessComplete = "Session complete! You scored %totalTimeLeftS!";							///< Session complete feedback message
 	String allSessComplete = "All Sessions Complete!";												///< All sessions complete feedback message
 
-	float fontSize = 20.0f;							///< Default font scale/size
-	Color4 color = Color3::yellow();				///< Color to draw the feedback message foreground
-	Color4 outlineColor = Color4::clear();			///< Color to draw the feedback message background
-	Color4 backgroundColor = Color4::clear();		///< Background color
+	float fontSize = 20.0f;											///< Default font scale/size
+
+	Color4 color = Color3(0.638f, 1.0f, 0.0f);						///< Color to draw the feedback message foreground
+	Color4 outlineColor = Color4::clear();							///< Color to draw the feedback message background
+	Color4 backgroundColor = Color4(0.0f, 0.0f, 0.0f, 0.5f);		///< Background color
 
 	void load(AnyTableReader reader, int settingsVersion = 1) {
 		switch (settingsVersion) {

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1606,6 +1606,11 @@ public:
 	String sessComplete = "Session complete! You scored %totalTimeLeftS!";							///< Session complete feedback message
 	String allSessComplete = "All Sessions Complete!";												///< All sessions complete feedback message
 
+	Color4 color = Color3::yellow();				///< Color to draw the feedback message foreground
+	Color4 outlineColor = Color4::clear();			///< Color to draw the feedback message background
+
+	float fontSize = 20.0f;							///< Default font scale/size
+
 	void load(AnyTableReader reader, int settingsVersion = 1) {
 		switch (settingsVersion) {
 		case 1:
@@ -1616,6 +1621,9 @@ public:
 			reader.getIfPresent("blockCompleteFeedback", blockComplete);
 			reader.getIfPresent("sessionCompleteFeedback", sessComplete);
 			reader.getIfPresent("allSessionsCompleteFeedback", allSessComplete);
+			reader.getIfPresent("feedbackColor", color);
+			reader.getIfPresent("feedbackOutlineColor", outlineColor);
+			reader.getIfPresent("feedbackFontSize", fontSize);
 			break;
 		default:
 			throw format("Did not recognize settings version: %d", settingsVersion);
@@ -1632,6 +1640,9 @@ public:
 		if (forceAll || def.blockComplete != blockComplete)		a["blockCompleteFeedback"] = blockComplete;
 		if (forceAll || def.sessComplete != sessComplete)		a["sessionCompleteFeedback"] = sessComplete;
 		if (forceAll || def.allSessComplete != allSessComplete) a["allSessionsCompleteFeedback"] = allSessComplete;
+		if (forceAll || def.color != color)						a["feedbackColor"] = color;
+		if (forceAll || def.outlineColor != outlineColor)		a["feedbackOutlineColor"] = outlineColor;
+		if (forceAll || def.fontSize != fontSize)				a["feedbackFontSize"] = fontSize;
 		return a;
 	}
 };

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1606,10 +1606,10 @@ public:
 	String sessComplete = "Session complete! You scored %totalTimeLeftS!";							///< Session complete feedback message
 	String allSessComplete = "All Sessions Complete!";												///< All sessions complete feedback message
 
+	float fontSize = 20.0f;							///< Default font scale/size
 	Color4 color = Color3::yellow();				///< Color to draw the feedback message foreground
 	Color4 outlineColor = Color4::clear();			///< Color to draw the feedback message background
-
-	float fontSize = 20.0f;							///< Default font scale/size
+	Color4 backgroundColor = Color4::clear();		///< Background color
 
 	void load(AnyTableReader reader, int settingsVersion = 1) {
 		switch (settingsVersion) {
@@ -1624,6 +1624,7 @@ public:
 			reader.getIfPresent("feedbackColor", color);
 			reader.getIfPresent("feedbackOutlineColor", outlineColor);
 			reader.getIfPresent("feedbackFontSize", fontSize);
+			reader.getIfPresent("feedbackBackgroundColor", backgroundColor);
 			break;
 		default:
 			throw format("Did not recognize settings version: %d", settingsVersion);
@@ -1643,6 +1644,7 @@ public:
 		if (forceAll || def.color != color)						a["feedbackColor"] = color;
 		if (forceAll || def.outlineColor != outlineColor)		a["feedbackOutlineColor"] = outlineColor;
 		if (forceAll || def.fontSize != fontSize)				a["feedbackFontSize"] = fontSize;
+		if (forceAll || def.backgroundColor != backgroundColor) a["feedbackBackgroundColor"] = backgroundColor;
 		return a;
 	}
 };

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1559,7 +1559,7 @@ public:
 	float           pretrialDuration = 0.5f;					///< Time in ready (pre-trial) state in seconds
 	float           maxTrialDuration = 100000.0f;				///< Maximum time spent in any one trial task
 	float           trialFeedbackDuration = 1.0f;				///< Time in the per-trial feedback state in seconds
-	float			sessionFeedbackDuration = 5.0f;				///< Time in the session feedback state in seconds
+	float			sessionFeedbackDuration = 2.0f;				///< Time in the session feedback state in seconds
 	bool			clickToStart = true;						///< Require a click before starting the first session (spawning the reference target)
 	bool			sessionFeedbackRequireClick = false;		///< Require a click to progress from the session feedback?
 

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -1397,7 +1397,12 @@ void FPSciApp::onGraphics2D(RenderDevice* rd, Array<shared_ptr<Surface2D>>& pose
 			String message = sess->getFeedbackMessage();
 			if (!message.empty()) {
 				outputFont->draw2D(rd, message.c_str(),
-					(Point2(rd->viewport().width()*0.5f, rd->viewport().height()*0.4f)).floor(), floor(20.0f * scale), Color3::yellow(), Color4::clear(), GFont::XALIGN_CENTER, GFont::YALIGN_CENTER);
+					(Point2(rd->viewport().width()*0.5f, rd->viewport().height()*0.4f)).floor(), 
+					floor(sessConfig->feedback.fontSize * scale),
+					sessConfig->feedback.color, 
+					sessConfig->feedback.outlineColor, 
+					GFont::XALIGN_CENTER, GFont::YALIGN_CENTER
+				);
 			}
 		}
 

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -1395,10 +1395,14 @@ void FPSciApp::onGraphics2D(RenderDevice* rd, Array<shared_ptr<Surface2D>>& pose
 
 			// Handle the feedback message
 			String message = sess->getFeedbackMessage();
+			const float centerHeight = rd->viewport().height() * 0.4f;
+			const float scaledFontSize = floor(sessConfig->feedback.fontSize * scale);
 			if (!message.empty()) {
+				// Draw a "back plate"
+				Draw::rect2D(Rect2D::xywh(0.0f, centerHeight - scaledFontSize, rd->viewport().width(), 2.0f * scaledFontSize), rd, sessConfig->feedback.backgroundColor);
 				outputFont->draw2D(rd, message.c_str(),
-					(Point2(rd->viewport().width()*0.5f, rd->viewport().height()*0.4f)).floor(), 
-					floor(sessConfig->feedback.fontSize * scale),
+					(Point2(rd->viewport().width() * 0.5f, centerHeight)).floor(),
+					scaledFontSize,
 					sessConfig->feedback.color, 
 					sessConfig->feedback.outlineColor, 
 					GFont::XALIGN_CENTER, GFont::YALIGN_CENTER


### PR DESCRIPTION
This branch adds support for additional feedback formatting, namely:

- Controllable text (outline) color
- Controllable font size
- Controllable/optional back plate (w/ alpha) to improve readability 

Merging this closes #231 
