### PR TITLE
Add new users

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -460,6 +460,7 @@ These flags control the display of the in-game user menu:
 |`showMenuLogo`                     |`bool`     |Show a logo at the top of the menu (currently `materials/FPSciLogo.png`) |
 |`showExperimentSettings`           |`bool`     |Show the options to select user/session                                |
 |`showUserSettings`                 |`bool`     |Show the per-user customization (sensitivity, reticle, etc) options    |
+|`allowUserAdd`                     |`bool`     |Allow users to add new users to the experiment                         |
 |`allowUserSettingsSave`            |`bool`     |Allow the user to save their settings from the menu                    |
 |`allowSensitivityChange`           |`bool`     |Allow the user to change their (cm/360) sensitivity value from the menu|
 |`allowTurnScaleChange`             |`bool`     |Allow the user to change their turn scale from the menu                |
@@ -478,6 +479,7 @@ These flags control the display of the in-game user menu:
 "showMenuLogo": true,                   // Show the logo
 "showExperimentSettings" : true,        // Allow user/session seleciton
 "showUserSettings": true,               // Show the user settings
+"allowUserAdd": false,                  // Don't allow new user add by default
 "allowUserSettingsSave": true,          // Allow the user to save their settings changes
 "allowSensitivityChange": true,         // Allow the user to change the cm/360 sensitivity
 "allowTurnScaleChange": true,           // Allow the user to change their turn scale (see below)

--- a/docs/userConfigReadme.md
+++ b/docs/userConfigReadme.md
@@ -8,6 +8,15 @@ The user config is setup to work across multiple experiments (i.e. it does not h
 ## File Location
 The `userconfig.Any` file is located in the [`data-files` directory](../data-files/) at the root of the project. If no `userconfig.Any` file is present the application writes a default to `userconfig.Any`. The default user is named `anon` and corresponds to the default `userstatus.Any` file. This config assumes an 800DPI mouse and a 12.75cm/360° mouse sensitivity without mouse inversion.
 
+# User ID Uniqueness
+The `requireUnique` flag is settable at the top of the user configuration file (defaults to `true`). When this flag is set to true, all users will be reuqired to have unique IDs. This is particularly useful when allowing users to enter their own user IDs using the `allowUserAdd` flag in the [user menu configuration](general_config.md#menu-config). Regardless of whether new users can be added in app,  will check for non-duplicate user IDs and throw an exception at startup.
+
+To disable the unique user ID requirement add the following to the top of your user config file:
+
+```
+requireUnique: False;
+```
+
 # User Table
 Each entry in the user table contains the following fields:
 

--- a/docs/userConfigReadme.md
+++ b/docs/userConfigReadme.md
@@ -1,7 +1,7 @@
 # Introduction
 The user config is the mechanism by which users are registered and provide their input sensitivity in `FirstPersonScience`.
 
-The high-level `userconfig.Any` file provides the `currentUser` (the default user when launching the application), together with a `users` table that contains per subject mouse DPI and sensitiviy (in cm/360°).
+The high-level `userconfig.Any` file provides the `currentUser` (the default user when launching the application), together with a `users` table that contains per subject mouse DPI and sensitivity (in cm/360°).
 
 The user config is setup to work across multiple experiments (i.e. it does not have any information specific to an `experimentconfig.Any` file contained within in). For per user session ordering see the [`userStatus.Any`](./userStatusReadme.md).
 
@@ -9,7 +9,7 @@ The user config is setup to work across multiple experiments (i.e. it does not h
 The `userconfig.Any` file is located in the [`data-files` directory](../data-files/) at the root of the project. If no `userconfig.Any` file is present the application writes a default to `userconfig.Any`. The default user is named `anon` and corresponds to the default `userstatus.Any` file. This config assumes an 800DPI mouse and a 12.75cm/360° mouse sensitivity without mouse inversion.
 
 # User ID Uniqueness
-The `requireUnique` flag is settable at the top of the user configuration file (defaults to `true`). When this flag is set to true, all users will be reuqired to have unique IDs. This is particularly useful when allowing users to enter their own user IDs using the `allowUserAdd` flag in the [user menu configuration](general_config.md#menu-config). Regardless of whether new users can be added in app,  will check for non-duplicate user IDs and throw an exception at startup.
+The `requireUnique` flag is settable at the top of the user configuration file (defaults to `true`). When this flag is set to true, all users will be required to have unique IDs. This is particularly useful when allowing users to enter their own user IDs using the `allowUserAdd` flag in the [user menu configuration](general_config.md#menu-config). Regardless of whether new users can be added in app,  will check for non-duplicate user IDs and throw an exception at startup.
 
 To disable the unique user ID requirement add the following to the top of your user config file:
 
@@ -61,7 +61,7 @@ The unit of mouse sensitivity measure selected for the application is `°/mm`. T
 1. It is (easily) related to the  common `cm/360°` measure
 2. It matches the intuition that high value ==> more sensitive (unlike `cmp360`)
 
-This unit is related to `cm/360°` (`cm/360° = 36 / (°/mm)`), since the distance (in mm) reuqired to make one full turn in game is just 360° / `°/mm`. Using this formula, a player can measure the full-turn distance for their game of choice, then transfer the setting into the abstract-fps application's user config.
+This unit is related to `cm/360°` (`cm/360° = 36 / (°/mm)`), since the distance (in mm) required to make one full turn in game is just 360° / `°/mm`. Using this formula, a player can measure the full-turn distance for their game of choice, then transfer the setting into the abstract-fps application's user config.
 
 Though the functionality is deprecated, since previous versions of `FPSci` supported using a `cmp360` variable, you can enter `cmp360` instead of `mouseDegPerMillimeter` in the user config and FPSci will convert it for you. If both `mouseDegPerMillimeter` and `cmp360` are found, then the `mouseDegPerMillimeter` will be used.
 

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1774,6 +1774,7 @@ public:
 	bool showMenuLogo					= true;							///< Show the FPSci logo in the user menu
 	bool showExperimentSettings			= true;							///< Show the experiment settings options (session/user selection)
 	bool showUserSettings				= true;							///< Show the user settings options (master switch)
+	bool allowUserAdd					= false;						///< Allow the user to add a new user to the experiment
 	bool allowUserSettingsSave			= true;							///< Allow the user to save settings changes
 	bool allowSensitivityChange			= true;							///< Allow in-game sensitivity change		
 	
@@ -1797,6 +1798,7 @@ public:
 			reader.getIfPresent("showMenuLogo", showMenuLogo);
 			reader.getIfPresent("showExperimentSettings", showExperimentSettings);
 			reader.getIfPresent("showUserSettings", showUserSettings);
+			reader.getIfPresent("allowUserAdd", allowUserAdd);
 			reader.getIfPresent("allowUserSettingsSave", allowUserSettingsSave);
 			reader.getIfPresent("allowSensitivityChange", allowSensitivityChange);
 			reader.getIfPresent("allowTurnScaleChange", allowTurnScaleChange);
@@ -1823,6 +1825,7 @@ public:
 		if (forceAll || def.showMenuLogo != showMenuLogo)									a["showMenuLogo"] = showMenuLogo;
 		if (forceAll || def.showExperimentSettings != showExperimentSettings)				a["showExperimentSettings"] = showExperimentSettings;
 		if (forceAll || def.showUserSettings != showUserSettings)							a["showUserSettings"] = showUserSettings;
+		if (forceAll || def.allowUserAdd != allowUserAdd)									a["allowUserAdd"] = allowUserAdd;
 		if (forceAll || def.allowUserSettingsSave != allowUserSettingsSave)					a["allowUserSettingsSave"] = allowUserSettingsSave;
 		if (forceAll || def.allowSensitivityChange != allowSensitivityChange)				a["allowSensitivityChange"] = allowSensitivityChange;
 		if (forceAll || def.allowTurnScaleChange != allowTurnScaleChange)					a["allowTurnScaleChange"] = allowTurnScaleChange;

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -440,6 +440,8 @@ public:
 /** Class for loading a user table and getting user info */
 class UserTable {
 public:
+
+	bool					requireUnique = true;			///< Require users to be unique by ID
 	Array<UserConfig>		users = {};						///< A list of valid users
 
 	UserTable() {};
@@ -452,7 +454,17 @@ public:
 
 		switch (settingsVersion) {
 		case 1:
+			reader.getIfPresent("requireUnique", requireUnique);
 			reader.get("users", users, "Issue in the (required) \"users\" array in the user config file!");
+			// Unique user check (if required)
+			if (requireUnique) {
+				const Array<String> userIds = getIds();
+				for (String id : userIds) {
+					if (userIds.findIndex(id) != userIds.rfindIndex(id)) {
+						throw "Multiple users with the same ID (\"" + id + "\") specified in the user config file!";
+					}
+				}
+			}
 			if (users.size() == 0) {
 				throw "At least 1 user must be specified in the \"users\" array within the user configuration file!";
 			}

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -1309,7 +1309,7 @@ void FPSciApp::onUserInput(UserInput* ui) {
 	}
 	
 	for (GKey dummyShoot : keyMap.map["dummyShoot"]) {
-		if (ui->keyPressed(dummyShoot) && (sess->currentState == PresentationState::trialFeedback)) {
+		if (ui->keyPressed(dummyShoot) && (sess->currentState == PresentationState::trialFeedback) && !m_userSettingsWindow->visible()) {
 			Array<shared_ptr<Entity>> dontHit;
 			dontHit.append(m_explosions);
 			dontHit.append(sess->unhittableTargets());

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -63,9 +63,9 @@ void FPSciApp::onInit() {
 	showRenderingStats = false;
 	makeGUI();
 
-	updateMouseSensitivity();									// Update (apply) mouse sensitivity
-	m_userSettingsWindow->updateSessionDropDown();				// Update the session drop down to remove already completed sessions
-	updateSession(m_userSettingsWindow->selectedSession());		// Update session to create results file/start collection
+	updateMouseSensitivity();		// Update (apply) mouse sensitivity
+	const Array<String> sessions = m_userSettingsWindow->updateSessionDropDown();	// Update the session drop down to remove already completed sessions
+	updateSession(sessions[0]);		// Update session to create results file/start collection
 
 	// Set the initial simulation timestep to REAL_TIME. The desired timestep is set later.
 	setFrameDuration(frameDuration(), REAL_TIME);

--- a/source/GuiElements.cpp
+++ b/source/GuiElements.cpp
@@ -339,6 +339,12 @@ UserMenu::UserMenu(FPSciApp* app, UserTable& users, UserStatusTable& userStatus,
 		m_userDropDown = m_expPane->addDropDownList("User", m_users.getIds(), &m_ddCurrUserIdx);
 		m_expPane->addButton("Select User", this, &UserMenu::updateUserPress);
 	} m_expPane->endRow();
+	if (m_config.allowUserAdd) {
+		m_expPane->beginRow(); {
+			m_expPane->addTextBox("New User", &m_newUser);
+			m_expPane->addButton("Add User", this, &UserMenu::addUserPress);
+		} m_expPane->endRow();
+	}
 	m_expPane->beginRow(); {
 		m_sessDropDown = m_expPane->addDropDownList("Session", Array<String>({}), &m_ddCurrSessIdx);
 		updateSessionDropDown();
@@ -593,6 +599,28 @@ void UserMenu::updateUserPress() {
 		const String sessId = updateSessionDropDown()[0];
 		m_app->updateSession(sessId);
 	}
+}
+
+void UserMenu::addUserPress() {
+	// Create new user
+	UserConfig user;
+	user.id = m_newUser;
+
+	// Add user to config and save
+	m_users.users.append(user);
+	m_app->saveUserConfig();
+
+	// Add user status and save
+	UserSessionStatus status = m_userStatus.userInfo.last();
+	status.id = m_newUser;
+	if (m_userStatus.randomizeDefaults) { status.sessionOrder.randomize(); }
+	m_userStatus.userInfo.append(status);
+	m_userStatus.currentUser = m_newUser;
+	m_app->saveUserStatus();
+
+	m_userDropDown->append(m_newUser);
+	m_ddCurrUserIdx = m_users.users.length() - 1;;
+	updateUserPress();
 }
 
 void UserMenu::updateReticlePreview() {

--- a/source/GuiElements.cpp
+++ b/source/GuiElements.cpp
@@ -618,6 +618,7 @@ void UserMenu::addUserPress() {
 	// Create new user config
 	UserConfig user;
 	user.id = m_newUser;
+	user.mouseDPI = m_users.users.last().mouseDPI;
 	
 	// Add user config to table and save
 	m_users.users.append(user);

--- a/source/GuiElements.h
+++ b/source/GuiElements.h
@@ -125,6 +125,7 @@ protected:
 
 	GuiDropDownList* m_userDropDown		= nullptr;				///< Dropdown menu for user selection
 	GuiDropDownList* m_sessDropDown		= nullptr;				///< Dropdown menu for session selection
+	GuiLabel* m_newUserFeedback			= nullptr;				///< Feedback field for new user
 
 	shared_ptr<Texture> m_reticlePreviewTexture;				///< Reticle preview texture
 	shared_ptr<Framebuffer> m_reticleBuffer;					///< Reticle preview framebuffer
@@ -169,9 +170,9 @@ public:
 		m_sessDropDown->setSelectedValue(id);
 	}
 
-	String selectedSession() const {
-		if (m_ddCurrSessIdx == -1) return "";
-		return m_sessDropDown->get(m_ddCurrSessIdx);
+	const String selectedSession() const {
+		if (m_ddCurrSessIdx >= m_sessDropDown->numElements()) return "";
+		return m_sessDropDown->get(m_ddCurrSessIdx).text();
 	}
 
 	int sessionsForSelectedUser() const {

--- a/source/GuiElements.h
+++ b/source/GuiElements.h
@@ -133,6 +133,8 @@ protected:
 	int m_ddCurrSessIdx = 0;									///< Current session index
 	int m_lastUserIdx = -1;										///< Previously selected user in the drop-down
 
+	String m_newUser;											///< New user string
+
 	double	m_cmp360;											///< cm/360° setting
 
 	const Vector2 m_btnSize = { 100.f, 30.f };					///< Default button size
@@ -146,6 +148,7 @@ protected:
 	void drawUserPane(const MenuConfig& config, UserConfig& user);
 
 	void updateUserPress();
+	void addUserPress();
 	void updateSessionPress();
 
 public:

--- a/source/GuiElements.h
+++ b/source/GuiElements.h
@@ -171,7 +171,7 @@ public:
 	}
 
 	const String selectedSession() const {
-		if (m_ddCurrSessIdx >= m_sessDropDown->numElements()) return "";
+		if (m_ddCurrSessIdx == -1 || m_ddCurrSessIdx >= m_sessDropDown->numElements()) return "";
 		return m_sessDropDown->get(m_ddCurrSessIdx).text();
 	}
 


### PR DESCRIPTION
This branch adds support for adding new users from within the application. As it a result it also adds:

- A user configuration flag to require unique user IDs (`requireUnique` in the user config)
- A user menu field/button for entering/adding new user IDs and a field providing feedback on empty/duplicate user IDs
- Support for automatically switching to the added user

Once new users are created the user can be directed to setup their mouse sensitivity and/or reticle (depending on what is allowed for the experiment) from the normal user menu.