### PR TITLE
Use hittable targets for projectile simulation

### DIFF
--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -645,7 +645,7 @@ void FPSciApp::onSimulation(RealTime rdt, SimTime sdt, SimTime idt) {
 	}
 
 	// Simulate the projectiles
-	m_weapon->simulateProjectiles(sdt, sess->targetArray());
+	m_weapon->simulateProjectiles(sdt, sess->hittableTargets());
 
 	// explosion animation
 	for (int i = 0; i < m_explosions.size(); i++) {


### PR DESCRIPTION
This branch fixes a bug wherein propagated (non-hitscanned) projectiles could destroy "preview" targets prior to the reference target being hit.

Merging this PR closes #246.