### PR TITLE
Add (optional) bullet spread

### DIFF
--- a/docs/weaponConfigReadme.md
+++ b/docs/weaponConfigReadme.md
@@ -26,7 +26,7 @@ This file provides information about the weapon to be used in the experiment. De
 |`autoFire`             |`bool`     | Whether or not the weapon fires when the left mouse is held, or requires release between fire         |
 |`damagePerSecond`      |damage/s   | The damage done by the weapon per second, when `firePeriod` > 0 the damage per round is set by `damagePerSecond`*`firePeriod`, when `firePeriod` is 0 and `autoFire` is `True` damage is computed based on time hitting the target.        |
 |`hitScan`              |`bool`     | Whether or not the weapon acts as an instantaneous hitscan (true) vs propagated projectile (false)    |
-|`fireSpread`           |`float`    | The angular (horizontal and vertical) spread of bullets fired from the weapon (no cooldown effect)    |
+|`fireSpreadDegrees`    |`float`    | The angular (horizontal and vertical) spread of bullets fired from the weapon in degrees (no cooldown effect) |
 |`fireSpreadShape`      |`String`   | The distributional shape to draw the fire spread from (can be `"uniform"` or `"gaussian"`). Invalid fire types will result in no spread. When using a `"gaussian"` distribution shape `fireSpread` is the width of the ±3σ interval. |
 
 ```
@@ -35,7 +35,7 @@ This file provides information about the weapon to be used in the experiment. De
     "autoFire": false;              // Single fire (no hold to fire)
     "damagePerSecond": 2.0;         // 1 damage per shot (single shot to destroy)
     "hitScan" : true;               // Use hitscan (not propogated projectile) for hit detection
-    "fireSpread": 0;                // No fire spread by default
+    "fireSpreadDegrees": 0;         // No fire spread by default
     "fireSpreadShape": "uniform";   // Uniform shape of fire spread distribution by default
 ```
 

--- a/docs/weaponConfigReadme.md
+++ b/docs/weaponConfigReadme.md
@@ -26,6 +26,7 @@ This file provides information about the weapon to be used in the experiment. De
 |`autoFire`             |`bool`     | Whether or not the weapon fires when the left mouse is held, or requires release between fire         |
 |`damagePerSecond`      |damage/s   | The damage done by the weapon per second, when `firePeriod` > 0 the damage per round is set by `damagePerSecond`*`firePeriod`, when `firePeriod` is 0 and `autoFire` is `True` damage is computed based on time hitting the target.        |
 |`hitScan`              |`bool`     | Whether or not the weapon acts as an instantaneous hitscan (true) vs propagated projectile (false)    |
+|`fireSpread`           |`float`    | The angular (horizontal and vertical) spread of bullets fired from the weapon (no cooldown effect)    |
 
 ```
     "maxAmmo" : 10000;              // Large ammo count
@@ -33,6 +34,7 @@ This file provides information about the weapon to be used in the experiment. De
     "autoFire": false;              // Single fire (no hold to fire)
     "damagePerSecond": 2.0;         // 1 damage per shot (single shot to destroy)
     "hitScan" : true;               // Use hitscan (not propogated projectile) for hit detection
+    "fireSpread": 0;                // No fire spread by default
 ```
 
 ## Sound and View Model

--- a/docs/weaponConfigReadme.md
+++ b/docs/weaponConfigReadme.md
@@ -27,7 +27,7 @@ This file provides information about the weapon to be used in the experiment. De
 |`damagePerSecond`      |damage/s   | The damage done by the weapon per second, when `firePeriod` > 0 the damage per round is set by `damagePerSecond`*`firePeriod`, when `firePeriod` is 0 and `autoFire` is `True` damage is computed based on time hitting the target.        |
 |`hitScan`              |`bool`     | Whether or not the weapon acts as an instantaneous hitscan (true) vs propagated projectile (false)    |
 |`fireSpreadDegrees`    |`float`    | The angular (horizontal and vertical) spread of bullets fired from the weapon in degrees (no cooldown effect) |
-|`fireSpreadShape`      |`String`   | The distributional shape to draw the fire spread from (can be `"uniform"` or `"gaussian"`). Invalid fire types will result in no spread. When using a `"gaussian"` distribution shape `fireSpread` is the width of the ±3σ interval. |
+|`fireSpreadShape`      |`String`   | The distributional shape to draw the fire spread from (can be `"uniform"` or `"gaussian"`). Invalid fire types will result in no spread. When using a `"gaussian"` distribution shape `fireSpreadDegrees` is the width of the ±3σ interval. |
 
 ```
     "maxAmmo" : 10000;              // Large ammo count

--- a/docs/weaponConfigReadme.md
+++ b/docs/weaponConfigReadme.md
@@ -27,6 +27,7 @@ This file provides information about the weapon to be used in the experiment. De
 |`damagePerSecond`      |damage/s   | The damage done by the weapon per second, when `firePeriod` > 0 the damage per round is set by `damagePerSecond`*`firePeriod`, when `firePeriod` is 0 and `autoFire` is `True` damage is computed based on time hitting the target.        |
 |`hitScan`              |`bool`     | Whether or not the weapon acts as an instantaneous hitscan (true) vs propagated projectile (false)    |
 |`fireSpread`           |`float`    | The angular (horizontal and vertical) spread of bullets fired from the weapon (no cooldown effect)    |
+|`fireSpreadShape`      |`String`   | The distributional shape to draw the fire spread from (can be `"uniform"` or `"gaussian"`). Invalid fire types will result in no spread. When using a `"gaussian"` distribution shape `fireSpread` is the width of the ±3σ interval. |
 
 ```
     "maxAmmo" : 10000;              // Large ammo count
@@ -35,6 +36,7 @@ This file provides information about the weapon to be used in the experiment. De
     "damagePerSecond": 2.0;         // 1 damage per shot (single shot to destroy)
     "hitScan" : true;               // Use hitscan (not propogated projectile) for hit detection
     "fireSpread": 0;                // No fire spread by default
+    "fireSpreadShape": "uniform";   // Uniform shape of fire spread distribution by default
 ```
 
 ## Sound and View Model

--- a/docs/weaponConfigReadme.md
+++ b/docs/weaponConfigReadme.md
@@ -26,7 +26,7 @@ This file provides information about the weapon to be used in the experiment. De
 |`autoFire`             |`bool`     | Whether or not the weapon fires when the left mouse is held, or requires release between fire         |
 |`damagePerSecond`      |damage/s   | The damage done by the weapon per second, when `firePeriod` > 0 the damage per round is set by `damagePerSecond`*`firePeriod`, when `firePeriod` is 0 and `autoFire` is `True` damage is computed based on time hitting the target.        |
 |`hitScan`              |`bool`     | Whether or not the weapon acts as an instantaneous hitscan (true) vs propagated projectile (false)    |
-|`fireSpreadDegrees`    |`float`    | The angular (horizontal and vertical) spread of bullets fired from the weapon in degrees (no cooldown effect) |
+|`fireSpreadDegrees`    |`float`    | The constant angular (horizontal and vertical) spread of bullets fired from the weapon in degrees. Clamps to 0 to 120 degrees. |
 |`fireSpreadShape`      |`String`   | The distributional shape to draw the fire spread from (can be `"uniform"` or `"gaussian"`). Invalid fire types will result in no spread. When using a `"gaussian"` distribution shape `fireSpreadDegrees` is the width of the ±3σ interval. |
 
 ```

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -763,6 +763,7 @@ public:
 	float	hitDecalColorMult = 2.0f;									///< "Encoding" field (aka color multiplier) for hit decal
 	
 	float	fireSpread = 0;												///< The spread of the fire
+	String  fireSpreadShape = "uniform";								///< The shape of the fire spread distribution
 	float	damageRollOffAim = 0;										///< Damage roll off w/ aim
 	float	damageRollOffDistance = 0;									///< Damage roll of w/ distance
 
@@ -824,6 +825,8 @@ public:
 			reader.getIfPresent("hitDecalColorMult", hitDecalColorMult);
 
 			reader.getIfPresent("fireSpread", fireSpread);
+			reader.getIfPresent("fireSpreadShape", fireSpreadShape);
+
 			reader.getIfPresent("damageRollOffAim", damageRollOffAim);
 			reader.getIfPresent("damageRollOffDistance", damageRollOffDistance);
 
@@ -871,6 +874,7 @@ public:
 		if (forceAll || def.hitDecalColorMult != hitDecalColorMult)			a["hitDecalColorMult"] = hitDecalColorMult;
 
 		if (forceAll || def.fireSpread != fireSpread)						a["fireSpread"] = fireSpread;
+		if (forceAll || def.fireSpreadShape != fireSpreadShape)				a["fireSpreadShape"] = fireSpreadShape;
 		if (forceAll || def.damageRollOffAim != damageRollOffAim)			a["damageRollOffAim"] = damageRollOffAim;
 		if (forceAll || def.damageRollOffDistance != damageRollOffDistance)	a["damageRollOffDistance"] = damageRollOffDistance;
 		if (forceAll || def.scopeFoV != scopeFoV)							a["scopeFoV"] = scopeFoV;

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -762,7 +762,7 @@ public:
 	float	hitDecalDurationS = 0.1f;									///< Duration to show the hit decal for (in seconds)
 	float	hitDecalColorMult = 2.0f;									///< "Encoding" field (aka color multiplier) for hit decal
 	
-	float	fireSpread = 0;												///< The spread of the fire
+	float	fireSpreadDegrees = 0;										///< The spread of the fire
 	String  fireSpreadShape = "uniform";								///< The shape of the fire spread distribution
 	float	damageRollOffAim = 0;										///< Damage roll off w/ aim
 	float	damageRollOffDistance = 0;									///< Damage roll of w/ distance
@@ -824,7 +824,7 @@ public:
 			reader.getIfPresent("hitDecalDuration", hitDecalDurationS);
 			reader.getIfPresent("hitDecalColorMult", hitDecalColorMult);
 
-			reader.getIfPresent("fireSpread", fireSpread);
+			reader.getIfPresent("fireSpreadDegrees", fireSpreadDegrees);
 			reader.getIfPresent("fireSpreadShape", fireSpreadShape);
 
 			reader.getIfPresent("damageRollOffAim", damageRollOffAim);
@@ -873,7 +873,7 @@ public:
 		if (forceAll || def.hitDecalDurationS != hitDecalDurationS)			a["hitDecalDuration"] = hitDecalDurationS;
 		if (forceAll || def.hitDecalColorMult != hitDecalColorMult)			a["hitDecalColorMult"] = hitDecalColorMult;
 
-		if (forceAll || def.fireSpread != fireSpread)						a["fireSpread"] = fireSpread;
+		if (forceAll || def.fireSpreadDegrees != fireSpreadDegrees)			a["fireSpreadDegrees"] = fireSpreadDegrees;
 		if (forceAll || def.fireSpreadShape != fireSpreadShape)				a["fireSpreadShape"] = fireSpreadShape;
 		if (forceAll || def.damageRollOffAim != damageRollOffAim)			a["damageRollOffAim"] = damageRollOffAim;
 		if (forceAll || def.damageRollOffDistance != damageRollOffDistance)	a["damageRollOffDistance"] = damageRollOffDistance;

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -1278,7 +1278,7 @@ void FPSciApp::onUserInput(UserInput* ui) {
 						float hitDist = finf();
 						int hitIdx = -1;
 
-						shared_ptr<TargetEntity> target = m_weapon->fire(sess->hittableTargets(), hitIdx, hitDist, info, dontHit);			// Fire the weapon
+						shared_ptr<TargetEntity> target = m_weapon->fire(sess->hittableTargets(), hitIdx, hitDist, info, dontHit, false);			// Fire the weapon
 						if (isNull(target)) // Miss case
 						{
 							// Play scene hit sound
@@ -1316,7 +1316,7 @@ void FPSciApp::onUserInput(UserInput* ui) {
 			Model::HitInfo info;
 			float hitDist = finf();
 			int hitIdx = -1;
-			shared_ptr<TargetEntity> target = m_weapon->fire(sess->hittableTargets(), hitIdx, hitDist, info, dontHit);			// Fire the weapon
+			shared_ptr<TargetEntity> target = m_weapon->fire(sess->hittableTargets(), hitIdx, hitDist, info, dontHit, true);			// Fire the weapon
 		}
 	}
 

--- a/source/GuiElements.cpp
+++ b/source/GuiElements.cpp
@@ -289,7 +289,7 @@ WeaponControls::WeaponControls(WeaponConfig& config, const shared_ptr<GuiTheme>&
 		n->setUnitsSize(50.0f);
 	} pane->endRow();
 	pane->beginRow(); {
-		pane->addNumberBox("Fire Spread", &(config.fireSpread), "deg", GuiTheme::LINEAR_SLIDER, 0.f, 40.f, 0.1f);
+		pane->addNumberBox("Fire Spread", &(config.fireSpreadDegrees), "\xB0", GuiTheme::LINEAR_SLIDER, 0.f, 40.f, 0.1f);
 		pane->addDropDownList("Spread Shape", m_spreadShapes, &m_spreadShapeIdx, std::bind(&WeaponControls::updateFireSpreadShape, this));
 	}
 	//pane->beginRow(); {
@@ -407,14 +407,14 @@ void UserMenu::drawUserPane(const MenuConfig& config, UserConfig& user)
 		dpiDisplay->setEnabled(false);
 	} sensPane->endRow();
 	sensPane->beginRow(); {
-		auto sensitivityNb = sensPane->addNumberBox("Sensitivity", &(user.mouseDegPerMm), "�/mm", GuiTheme::LOG_SLIDER, 0.01, 100.0, 0.01);
+		auto sensitivityNb = sensPane->addNumberBox("Sensitivity", &(user.mouseDegPerMm), "\xB0/mm", GuiTheme::LOG_SLIDER, 0.01, 100.0, 0.01);
 		sensitivityNb->setWidth(300.0);
 		sensitivityNb->setCaptionWidth(captionWidth);
 		sensitivityNb->setUnitsSize(unitSize);
 		sensitivityNb->setEnabled(config.allowSensitivityChange);
 	} sensPane->endRow();
 	sensPane->beginRow(); {
-		auto cmp360Nb = sensPane->addNumberBox("", &m_cmp360, "cm/360�", GuiTheme::NO_SLIDER, 0.0, 3600.0, 0.1);
+		auto cmp360Nb = sensPane->addNumberBox("", &m_cmp360, "cm/360\xB0", GuiTheme::NO_SLIDER, 0.0, 3600.0, 0.1);
 		cmp360Nb->setWidth(180.0);
 		cmp360Nb->setCaptionWidth(captionWidth);
 		cmp360Nb->setUnitsSize(unitSize);

--- a/source/GuiElements.cpp
+++ b/source/GuiElements.cpp
@@ -271,8 +271,8 @@ void RenderControls::updateUserMenu() {
 	m_app->updateUserMenu = true;					// Set the semaphore to update the user menu
 }
 
-WeaponControls::WeaponControls(WeaponConfig& config, const shared_ptr<GuiTheme>& theme, float width, float height) : 
-	GuiWindow("Weapon Controls", theme, Rect2D::xywh(5, 5, width, height), GuiTheme::NORMAL_WINDOW_STYLE, GuiWindow::HIDE_ON_CLOSE)
+WeaponControls::WeaponControls(WeaponConfig& config, const shared_ptr<GuiTheme>& theme, float width, float height) :
+	GuiWindow("Weapon Controls", theme, Rect2D::xywh(5, 5, width, height), GuiTheme::NORMAL_WINDOW_STYLE, GuiWindow::HIDE_ON_CLOSE), m_config(config)
 {
 	// Create the GUI pane
 	GuiPane* pane = GuiWindow::pane();
@@ -283,10 +283,15 @@ WeaponControls::WeaponControls(WeaponConfig& config, const shared_ptr<GuiTheme>&
 		pane->addCheckBox("Autofire", &(config.autoFire));
 	} pane->endRow();
 	pane->beginRow(); {
+		pane->addCheckBox("Hitscan", &(config.hitScan));
 		auto n = pane->addNumberBox("Damage", &(config.damagePerSecond), "health/s", GuiTheme::LINEAR_SLIDER, 0.0f, 100.0f, 0.1f);
 		n->setWidth(300.0f);
 		n->setUnitsSize(50.0f);
 	} pane->endRow();
+	pane->beginRow(); {
+		pane->addNumberBox("Fire Spread", &(config.fireSpread), "deg", GuiTheme::LINEAR_SLIDER, 0.f, 40.f, 0.1f);
+		pane->addDropDownList("Spread Shape", m_spreadShapes, &m_spreadShapeIdx, std::bind(&WeaponControls::updateFireSpreadShape, this));
+	}
 	//pane->beginRow(); {
 	//	auto c = pane->addLabel("Muzzle offset");
 	//	c->setWidth(100.0f);
@@ -306,6 +311,10 @@ WeaponControls::WeaponControls(WeaponConfig& config, const shared_ptr<GuiTheme>&
 
 	pack();
 	moveTo(Vector2(0, 720));
+}
+
+void WeaponControls::updateFireSpreadShape() {
+	m_config.fireSpreadShape = m_spreadShapes[m_spreadShapeIdx];
 }
 
 ////////////////////////
@@ -398,14 +407,14 @@ void UserMenu::drawUserPane(const MenuConfig& config, UserConfig& user)
 		dpiDisplay->setEnabled(false);
 	} sensPane->endRow();
 	sensPane->beginRow(); {
-		auto sensitivityNb = sensPane->addNumberBox("Sensitivity", &(user.mouseDegPerMm), "°/mm", GuiTheme::LOG_SLIDER, 0.01, 100.0, 0.01);
+		auto sensitivityNb = sensPane->addNumberBox("Sensitivity", &(user.mouseDegPerMm), "ï¿½/mm", GuiTheme::LOG_SLIDER, 0.01, 100.0, 0.01);
 		sensitivityNb->setWidth(300.0);
 		sensitivityNb->setCaptionWidth(captionWidth);
 		sensitivityNb->setUnitsSize(unitSize);
 		sensitivityNb->setEnabled(config.allowSensitivityChange);
 	} sensPane->endRow();
 	sensPane->beginRow(); {
-		auto cmp360Nb = sensPane->addNumberBox("", &m_cmp360, "cm/360°", GuiTheme::NO_SLIDER, 0.0, 3600.0, 0.1);
+		auto cmp360Nb = sensPane->addNumberBox("", &m_cmp360, "cm/360ï¿½", GuiTheme::NO_SLIDER, 0.0, 3600.0, 0.1);
 		cmp360Nb->setWidth(180.0);
 		cmp360Nb->setCaptionWidth(captionWidth);
 		cmp360Nb->setUnitsSize(unitSize);

--- a/source/GuiElements.cpp
+++ b/source/GuiElements.cpp
@@ -289,7 +289,8 @@ WeaponControls::WeaponControls(WeaponConfig& config, const shared_ptr<GuiTheme>&
 		n->setUnitsSize(50.0f);
 	} pane->endRow();
 	pane->beginRow(); {
-		pane->addNumberBox("Fire Spread", &(config.fireSpreadDegrees), "\xB0", GuiTheme::LINEAR_SLIDER, 0.f, 40.f, 0.1f);
+		pane->addNumberBox("Fire Spread", &(config.fireSpreadDegrees), "\xB0", GuiTheme::LINEAR_SLIDER, 0.f, 120.f, 0.1f);
+		m_spreadShapeIdx = m_spreadShapes.findIndex(m_config.fireSpreadShape);
 		pane->addDropDownList("Spread Shape", m_spreadShapes, &m_spreadShapeIdx, std::bind(&WeaponControls::updateFireSpreadShape, this));
 	}
 	//pane->beginRow(); {

--- a/source/GuiElements.h
+++ b/source/GuiElements.h
@@ -103,6 +103,12 @@ public:
 
 class WeaponControls : public GuiWindow {
 protected:
+	int	m_spreadShapeIdx = 0;											// Index of fire spread shape
+	const Array<String> m_spreadShapes = { "uniform", "gaussian" };		// Optional shapes to select from
+	void updateFireSpreadShape(void);
+
+	WeaponConfig& m_config;
+
 	WeaponControls(WeaponConfig& config, const shared_ptr<GuiTheme>& theme, float width = 400.0f, float height = 10.0f);
 public:
 	static shared_ptr<WeaponControls> create(WeaponConfig& config, const shared_ptr<GuiTheme>& theme, float width = 400.0f, float height = 10.0f) {

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -203,7 +203,15 @@ shared_ptr<TargetEntity> Weapon::fire(
 	static RealTime lastTime;
 	Ray ray = m_camera->frame().lookRay();		// Use the camera lookray for hit detection
 	const float spread = m_config->fireSpread * 2.f * pif() / 360.f;
-	Matrix3 rotMat = Matrix3::fromEulerAnglesXYZ(m_rand.uniform(-spread/2, spread/2) , m_rand.uniform(-spread / 2, spread / 2), 0);
+
+	// Apply random rotation (for fire spread)
+	Matrix3 rotMat = Matrix3::fromEulerAnglesXYZ(0.f,0.f,0.f);
+	if (m_config->fireSpreadShape == "uniform") {
+		rotMat = Matrix3::fromEulerAnglesXYZ(m_rand.uniform(-spread / 2, spread / 2), m_rand.uniform(-spread / 2, spread / 2), 0);
+	}
+	else if (m_config->fireSpreadShape == "gaussian") {
+		rotMat = Matrix3::fromEulerAnglesXYZ(m_rand.gaussian(0, spread / 3), m_rand.gaussian(0, spread / 3), 0);
+	}
 	Vector3 dir = ray.direction() * rotMat;
 	ray.set(ray.origin(), dir);
 

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -198,11 +198,17 @@ shared_ptr<TargetEntity> Weapon::fire(
 	int& targetIdx, 
 	float& hitDist, 
 	Model::HitInfo& hitInfo, 
-	Array<shared_ptr<Entity>>& dontHit)
+	Array<shared_ptr<Entity>>& dontHit,
+	bool dummyShot)
 {
 	static RealTime lastTime;
 	Ray ray = m_camera->frame().lookRay();		// Use the camera lookray for hit detection
-	const float spread = m_config->fireSpreadDegrees * 2.f * pif() / 360.f;
+	float spread = m_config->fireSpreadDegrees * 2.f * pif() / 360.f;
+
+	// ignore bullet spread on dummy targets
+	if (dummyShot) {
+		spread = 0.f;
+	}
 
 	// Apply random rotation (for fire spread)
 	Matrix3 rotMat = Matrix3::fromEulerAnglesXYZ(0.f,0.f,0.f);

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -213,10 +213,10 @@ shared_ptr<TargetEntity> Weapon::fire(
 	// Apply random rotation (for fire spread)
 	Matrix3 rotMat = Matrix3::fromEulerAnglesXYZ(0.f,0.f,0.f);
 	if (m_config->fireSpreadShape == "uniform") {
-		rotMat = Matrix3::fromEulerAnglesXYZ(m_rand.uniform(-spread / 2, spread / 2), m_rand.uniform(-spread / 2, spread / 2), 0);
+		rotMat = Matrix3::fromEulerAnglesXYZ(0, m_rand.uniform(-spread / 2, spread / 2), m_rand.uniform(-spread / 2, spread / 2));
 	}
 	else if (m_config->fireSpreadShape == "gaussian") {
-		rotMat = Matrix3::fromEulerAnglesXYZ(m_rand.gaussian(0, spread / 3), m_rand.gaussian(0, spread / 3), 0);
+		rotMat = Matrix3::fromEulerAnglesXYZ(0, m_rand.gaussian(0, spread / 3), m_rand.gaussian(0, spread / 3));
 	}
 	Vector3 dir = ray.direction() * rotMat;
 	ray.set(ray.origin(), dir);

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -202,7 +202,7 @@ shared_ptr<TargetEntity> Weapon::fire(
 {
 	static RealTime lastTime;
 	Ray ray = m_camera->frame().lookRay();		// Use the camera lookray for hit detection
-	const float spread = m_config->fireSpread * 2.f * pif() / 360.f;
+	const float spread = m_config->fireSpreadDegrees * 2.f * pif() / 360.f;
 
 	// Apply random rotation (for fire spread)
 	Matrix3 rotMat = Matrix3::fromEulerAnglesXYZ(0.f,0.f,0.f);

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -213,13 +213,13 @@ shared_ptr<TargetEntity> Weapon::fire(
 	// Apply random rotation (for fire spread)
 	Matrix3 rotMat = Matrix3::fromEulerAnglesXYZ(0.f,0.f,0.f);
 	if (m_config->fireSpreadShape == "uniform") {
-		rotMat = Matrix3::fromEulerAnglesXYZ(0, m_rand.uniform(-spread / 2, spread / 2), m_rand.uniform(-spread / 2, spread / 2));
+		rotMat = Matrix3::fromEulerAnglesXYZ(m_rand.uniform(-spread / 2, spread / 2), m_rand.uniform(-spread / 2, spread / 2), 0);
 	}
 	else if (m_config->fireSpreadShape == "gaussian") {
-		rotMat = Matrix3::fromEulerAnglesXYZ(0, m_rand.gaussian(0, spread / 3), m_rand.gaussian(0, spread / 3));
+		rotMat = Matrix3::fromEulerAnglesXYZ(m_rand.gaussian(0, spread / 3), m_rand.gaussian(0, spread / 3), 0);
 	}
-	Vector3 dir = ray.direction() * rotMat;
-	ray.set(ray.origin(), dir);
+	Vector3 dir = Vector3(0.f, 0.f, -1.f) * rotMat;
+	ray.set(ray.origin(), m_camera->frame().rotation * dir);
 
 	// Check for closest hit (in scene, otherwise this ray hits the skybox)
 	float closest = finf();

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -96,6 +96,8 @@ protected:
 	RealTime								m_hitDecalTimeRemainingS = 0.f;		///< Remaining duration to show the decal for
 	Array<shared_ptr<VisibleEntity>>		m_currentMissDecals;				///< Pointers to miss decals
 
+	Random									m_rand;
+
 public:
 	static shared_ptr<Weapon> create(WeaponConfig* config, shared_ptr<Scene> scene, shared_ptr<Camera> cam) {
 		return createShared<Weapon>(config, scene, cam);

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -107,7 +107,8 @@ public:
 		int& targetIdx,
 		float& hitDist, 
 		Model::HitInfo& hitInfo, 
-		Array<shared_ptr<Entity>>& dontHit);
+		Array<shared_ptr<Entity>>& dontHit,
+		bool dummyShot);
 
 	void onPose(Array<shared_ptr<Surface> >& surface);
 


### PR DESCRIPTION
This branch adds support for bullet spread via the `fireSpread` configuration parameter in the weapon configuration. By default this spread value is set to 0, maintaining the purely deterministic shot behavior previously used in FPSci.

Currently the fire "spread" is shot-to-shot and uniformly distributed/sized in azimuth/elevation with no effects of things like the time since the last shot was made. If we'd like we can extend this to include:

- Impact of time since the last shot
- Asymmetric azimuth and elevation spread
- Support for multiple projectiles in a single shot

This branch does not currently support changing the damage of the weapon based on shot spread (i.e. distance from central aim direction) in any way.