### PR TITLE
Add allowSessionChange control flag

### DIFF
--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -460,6 +460,7 @@ These flags control the display of the in-game user menu:
 |`showMenuLogo`                     |`bool`     |Show a logo at the top of the menu (currently `materials/FPSciLogo.png`) |
 |`showExperimentSettings`           |`bool`     |Show the options to select user/session                                |
 |`showUserSettings`                 |`bool`     |Show the per-user customization (sensitivity, reticle, etc) options    |
+|`allowSessionChange`               |`bool`     |Allow users to change the session using a user menu dropdown           |
 |`allowUserAdd`                     |`bool`     |Allow users to add new users to the experiment                         |
 |`allowUserSettingsSave`            |`bool`     |Allow the user to save their settings from the menu                    |
 |`allowSensitivityChange`           |`bool`     |Allow the user to change their (cm/360) sensitivity value from the menu|
@@ -479,6 +480,7 @@ These flags control the display of the in-game user menu:
 "showMenuLogo": true,                   // Show the logo
 "showExperimentSettings" : true,        // Allow user/session seleciton
 "showUserSettings": true,               // Show the user settings
+"allowSessionChange": true,             // Allow the user to change sessiions using the menu dropdown
 "allowUserAdd": false,                  // Don't allow new user add by default
 "allowUserSettingsSave": true,          // Allow the user to save their settings changes
 "allowSensitivityChange": true,         // Allow the user to change the cm/360 sensitivity

--- a/docs/general_config.md
+++ b/docs/general_config.md
@@ -480,7 +480,7 @@ These flags control the display of the in-game user menu:
 "showMenuLogo": true,                   // Show the logo
 "showExperimentSettings" : true,        // Allow user/session seleciton
 "showUserSettings": true,               // Show the user settings
-"allowSessionChange": true,             // Allow the user to change sessiions using the menu dropdown
+"allowSessionChange": true,             // Allow the user to change sessions using the menu dropdown
 "allowUserAdd": false,                  // Don't allow new user add by default
 "allowUserSettingsSave": true,          // Allow the user to save their settings changes
 "allowSensitivityChange": true,         // Allow the user to change the cm/360 sensitivity

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1788,6 +1788,7 @@ public:
 	bool showMenuLogo					= true;							///< Show the FPSci logo in the user menu
 	bool showExperimentSettings			= true;							///< Show the experiment settings options (session/user selection)
 	bool showUserSettings				= true;							///< Show the user settings options (master switch)
+	bool allowSessionChange				= true;							///< Allow the user to change the session with the menu drop-down
 	bool allowUserAdd					= false;						///< Allow the user to add a new user to the experiment
 	bool allowUserSettingsSave			= true;							///< Allow the user to save settings changes
 	bool allowSensitivityChange			= true;							///< Allow in-game sensitivity change		
@@ -1812,6 +1813,7 @@ public:
 			reader.getIfPresent("showMenuLogo", showMenuLogo);
 			reader.getIfPresent("showExperimentSettings", showExperimentSettings);
 			reader.getIfPresent("showUserSettings", showUserSettings);
+			reader.getIfPresent("allowSessionChange", allowSessionChange);
 			reader.getIfPresent("allowUserAdd", allowUserAdd);
 			reader.getIfPresent("allowUserSettingsSave", allowUserSettingsSave);
 			reader.getIfPresent("allowSensitivityChange", allowSensitivityChange);
@@ -1839,6 +1841,7 @@ public:
 		if (forceAll || def.showMenuLogo != showMenuLogo)									a["showMenuLogo"] = showMenuLogo;
 		if (forceAll || def.showExperimentSettings != showExperimentSettings)				a["showExperimentSettings"] = showExperimentSettings;
 		if (forceAll || def.showUserSettings != showUserSettings)							a["showUserSettings"] = showUserSettings;
+		if (forceAll || def.allowSessionChange != allowSessionChange)						a["allowSessionChange"] = allowSessionChange;
 		if (forceAll || def.allowUserAdd != allowUserAdd)									a["allowUserAdd"] = allowUserAdd;
 		if (forceAll || def.allowUserSettingsSave != allowUserSettingsSave)					a["allowUserSettingsSave"] = allowUserSettingsSave;
 		if (forceAll || def.allowSensitivityChange != allowSensitivityChange)				a["allowSensitivityChange"] = allowSensitivityChange;

--- a/source/GuiElements.cpp
+++ b/source/GuiElements.cpp
@@ -347,11 +347,14 @@ UserMenu::UserMenu(FPSciApp* app, UserTable& users, UserStatusTable& userStatus,
 			m_newUserFeedback->setWidth(70.f);
 		} m_expPane->endRow();
 	}
+	GuiButton* addBtn;
 	m_expPane->beginRow(); {
 		m_sessDropDown = m_expPane->addDropDownList("Session", Array<String>({}), &m_ddCurrSessIdx);
 		updateSessionDropDown();
-		m_expPane->addButton("Select Session", this, &UserMenu::updateSessionPress);
+		addBtn = m_expPane->addButton("Select Session", this, &UserMenu::updateSessionPress);
 	} m_expPane->endRow();
+	m_sessDropDown->setVisible(m_config.allowSessionChange);
+	addBtn->setVisible(m_config.allowSessionChange);
 
 	// Hide the experiment settings if not requested to be drawn
 	if (!config.showExperimentSettings) { 


### PR DESCRIPTION
This branch adds an `allowSessionChange` control flag to disable users from updating the session from the user menu.