### PR TITLE
Add check/documentation for trial count > 0

### DIFF
--- a/docs/experimentConfigReadme.md
+++ b/docs/experimentConfigReadme.md
@@ -36,7 +36,7 @@ In addition to these general parameters each session also has a few unique param
     * `blockCount` is an integer number of (repeated) groups of trials within a session, with the block number printed to the screen between "blocks" (or a single "default" block if not provided).
     * `trials` is a list of trials referencing the `trials` table above:
         * `ids` is a list of short names for the trial(s) to affiliate with the `targets` or `reactions` table below, if multiple ids are provided multiple target are spawned simultaneously in each trial
-        * `count` provides the number of trials in this session
+        * `count` provides the number of trials in this session (should always be an integer strictly greater than 0)
 
 #### Session Configuration Example
 An example session configuration snippet is included below:

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1078,10 +1078,7 @@ public:
 				count = defaultCount;
 			}
 			if(count < 1) {
-				String ids_str = "[";
-				for (auto id : ids) ids_str.append(id + ", ");
-				ids_str = ids_str.substr(0, ids_str.length() - 2); ids_str += "]";
-				throw format("Trial count < 1 not allowed! (%d count for trial with targets: %s)", count, ids_str);
+				throw format("Trial count < 1 not allowed! (%d count for trial with targets: %s)", count, Any(ids).unparse());
 			}
 			break;
 		default:

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -1077,6 +1077,12 @@ public:
 			if (!reader.getIfPresent("count", count)) {
 				count = defaultCount;
 			}
+			if(count < 1) {
+				String ids_str = "[";
+				for (auto id : ids) ids_str.append(id + ", ");
+				ids_str = ids_str.substr(0, ids_str.length() - 2); ids_str += "]";
+				throw format("Trial count < 1 not allowed! (%d count for trial with targets: %s)", count, ids_str);
+			}
 			break;
 		default:
 			debugPrintf("Settings version '%d' not recognized in SessionConfig.\n", settingsVersion);


### PR DESCRIPTION
Previously setting a trial's `count` field to a value <= 0 caused a session management glitch within the application. This branch adds support for documenting that the `count` should be an integer >0 and adds an exception to catch this case, preventing the app from entering the session logic glitch.