### PR TITLE
Experiment selection

### DIFF
--- a/docs/developermode.md
+++ b/docs/developermode.md
@@ -5,6 +5,7 @@ During development of `FirstPersonScience` we created a number of utilities for 
 When running in developer mode a number of the otherwise static features of the tool are available for dynamic toggle via an expanded Heads Up Display menu accessible during the normally available pause (Tab) menu.
 
 Features include:
+* Switching between multiple experiments (as specified in the `experimentList` within (startup config)[startupConfigReadme.md])
 * Dynamic control of bullet rendering
 * Dynamic control of HUD rendering
 * Dynamic control of on-screen FPS monitoring

--- a/docs/startupConfigReadme.md
+++ b/docs/startupConfigReadme.md
@@ -24,6 +24,7 @@ The following fields are specified on a per-experiment basis:
 * `keymapConfigFilename` sets the path and file name for a [keymap config file](./keymap.md).
 * `systemConfigFilename` sets the path and file name for a [system config file](systemConfigReadme.md) for controlling latency logger hardware.
 * `resultsDirPath` sets the path to the results directory. If this directory does not exists the application will create it at runtime.
+* `name` is the name identifier for each entry in the `experimentList`.
 
 ## Sample/Default Values
 The default `startup.Any` file is included below (as an example):
@@ -42,4 +43,37 @@ defaultExperiment = {
     systemConfigFilename = "systemconfig.Any";          // Can include a path
     resultsDirPath = "./results/";                      // Change to save results somewhere else
 };
+```
+
+As an example of how to use the `experimentList`, let's say we have 2 experiments that use the same userConfig, keymap, and results, but have their own experimentConfig and userStatus to track progress. The `experimentList` for this example might look something like the following:
+
+```
+{
+    audioEnable = true; 
+    developerMode = true; 
+    fullscreen = false; 
+    waypointEditorMode = false; 
+    defaultExperiment = {
+        name = "default";                                   // Note that `name` is required and "default" is recommended here
+        experimentConfigFilename = "experimentconfig.Any"; 
+        userStatusFilename = "userstatus.Any"; 
+        userConfigFilename = "userconfig.Any"; 
+        resultsDirPath = "./results/"; 
+        systemConfigFilename = "systemconfig.Any"; 
+        keymapConfigFilename = "keymap.Any"; 
+    };
+    experimentList = [
+        { name = "default"; }, // include this if you want the default experiment in the list
+        {
+            name = "experiment1";
+            experimentConfigFilename = "greatExperiment.Any"; 
+            userStatusFilename = "greatUserstatus.Any"; 
+        },
+        {
+            name = "experiment2";
+            experimentConfigFilename = "betterExperiment.Any"; 
+            userStatusFilename = "betterUserstatus.Any"; 
+        },
+    ];
+}
 ```

--- a/docs/startupConfigReadme.md
+++ b/docs/startupConfigReadme.md
@@ -36,6 +36,7 @@ windowSize = Vector2(1920, 980);                    // This sets the default win
 audioEnable = true;                                 // Set false to turn off audio
 
 defaultExperiment = {
+    name = "default";
     experimentConfigFilename = "experimentconfig.Any";  // Can include a path
     userConfigFilename = "userconfig.Any";              // Can include a path
     userStatusFilename = "userstatus.Any";              // Can include a path
@@ -54,7 +55,7 @@ As an example of how to use the `experimentList`, let's say we have 2 experiment
     fullscreen = false; 
     waypointEditorMode = false; 
     defaultExperiment = {
-        name = "default";                                   // Note that `name` is required and "default" is recommended here
+        name = "default";                                   // Note that `name` is required and "default" is useful if using an `experimentList`
         experimentConfigFilename = "experimentconfig.Any"; 
         userStatusFilename = "userstatus.Any"; 
         userConfigFilename = "userconfig.Any"; 

--- a/docs/startupConfigReadme.md
+++ b/docs/startupConfigReadme.md
@@ -11,13 +11,19 @@ The following fields are valid for a startupconfig.Any file:
 * `waypointEditorMode` controls whether the application is run including additional support for [target path creation/waypoint editing](./patheditor.md). Waypoint editor mode **only applies when `developerMode`=`true`**! In waypoint editor mode an additional menu is made available and the user can drop waypoints or start/stop record their motion using key bound functions.
 * `fullscreen` controls whether the application is run in fullscreen mode or windowed (independent of other options)
 * `windowSize` controls the (default) window size when running in windowed mode (`fullscreen`=`false`) as a `Vector2`. The window can then be resized from this default while running.
+* `defaultExperiment` controls the default set of files to use for the experiment, these values are inherited by any unspecified values from experiments in the `experimentList` (see below)
+* `experimentList` optionally specifies a list of experiments that can be selected from in developer mode, if none is provided a single experiment that matches the `defaultExperiment` specification is used
+* `audioEnable` turns on or off audio
+
+## Experiment Specification
+The following fields are specified on a per-experiment basis:
+
 * `experimentConfigFilename` sets the path and file name for an [experiment config file](./experimentConfigReadme.md).
 * `userConfigFilename` sets the path and file name for a [user config file](./userConfigReadme.md).
 * `userStatusFilename` sets the path and file name for a [user status file](./userStatusReadme.md).
 * `keymapConfigFilename` sets the path and file name for a [keymap config file](./keymap.md).
 * `systemConfigFilename` sets the path and file name for a [system config file](systemConfigReadme.md) for controlling latency logger hardware.
 * `resultsDirPath` sets the path to the results directory. If this directory does not exists the application will create it at runtime.
-* `audioEnable` turns on or off audio
 
 ## Sample/Default Values
 The default `startup.Any` file is included below (as an example):
@@ -26,11 +32,14 @@ developerMode = false;                              // Set this to true to enabl
 waypointEditorMode = false;                         // Set this to true to enable waypoint editor mode (target path creation)
 fullscreen = true;                                  // Set this to false to run in windowed mode
 windowSize = Vector2(1920, 980);                    // This sets the default window size (when running with fullscreen = false)
-experimentConfigFilename = "experimentconfig.Any";  // Can include a path
-userConfigFilename = "userconfig.Any";              // Can include a path
-userStatusFilename = "userstatus.Any";              // Can include a path
-keymapConfigFilename = "keymap.Any";                // Can include a path
-systemConfigFilename = "systemconfig.Any";          // Can include a path
-resultsDirPath = "./results/";                      // Change to save results somewhere else
 audioEnable = true;                                 // Set false to turn off audio
+
+defaultExperiment = {
+    experimentConfigFilename = "experimentconfig.Any";  // Can include a path
+    userConfigFilename = "userconfig.Any";              // Can include a path
+    userStatusFilename = "userstatus.Any";              // Can include a path
+    keymapConfigFilename = "keymap.Any";                // Can include a path
+    systemConfigFilename = "systemconfig.Any";          // Can include a path
+    resultsDirPath = "./results/";                      // Change to save results somewhere else
+};
 ```

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -133,13 +133,14 @@ public:
 				reader.getIfPresent("resultsDirPath", resultsDirPath);
 				logPrintf("One possible fix is to use the following in `startupConfig.Any`:\n");
 				logPrintf("    defaultExperiment = {\n");
+				logPrintf("        name = \"default\";\n");
 				logPrintf("        experimentConfigFilename = \"%s\";\n", experimentConfigFilename);
 				logPrintf("        userConfigFilename = \"%s\";\n", userConfigFilename);
 				logPrintf("        userStatusFilename = \"%s\";\n", userStatusFilename);
 				logPrintf("        keymapConfigFilename = \"%s\";\n", keymapConfigFilename);
 				logPrintf("        systemConfigFilename = \"%s\";\n", systemConfigFilename);
 				logPrintf("        resultsDirPath = \"%s\";\n", resultsDirPath);
-				logPrintf("    }\n");
+				logPrintf("    };\n");
 			}
 
 			reader.getIfPresent("experimentList", experimentList);

--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -109,6 +109,7 @@ public:
 
 	/** Construct from any here */
     StartupConfig(const Any& any) {
+		bool foundDefault = false;
         int settingsVersion = 1;
         AnyTableReader reader(any);
         reader.getIfPresent("settingsVersion", settingsVersion);
@@ -120,7 +121,27 @@ public:
 			reader.getIfPresent("fullscreen", fullscreen);
 			reader.getIfPresent("windowSize", windowSize);
 
-			reader.getIfPresent("defaultExperiment", defaultExperiment);
+			foundDefault = reader.getIfPresent("defaultExperiment", defaultExperiment);
+			if (!foundDefault) {
+				logPrintf("Warning: no `defaultExperiment` found in `startupConfig.Any`, you may be using an old experiment config.\n");
+				String experimentConfigFilename, userConfigFilename, userStatusFilename, keymapConfigFilename, systemConfigFilename, resultsDirPath;
+				reader.getIfPresent("experimentConfigFilename", experimentConfigFilename);
+				reader.getIfPresent("userConfigFilename", userConfigFilename);
+				reader.getIfPresent("userStatusFilename", userStatusFilename);
+				reader.getIfPresent("keymapConfigFilename", keymapConfigFilename);
+				reader.getIfPresent("systemConfigFilename", systemConfigFilename);
+				reader.getIfPresent("resultsDirPath", resultsDirPath);
+				logPrintf("One possible fix is to use the following in `startupConfig.Any`:\n");
+				logPrintf("    defaultExperiment = {\n");
+				logPrintf("        experimentConfigFilename = \"%s\";\n", experimentConfigFilename);
+				logPrintf("        userConfigFilename = \"%s\";\n", userConfigFilename);
+				logPrintf("        userStatusFilename = \"%s\";\n", userStatusFilename);
+				logPrintf("        keymapConfigFilename = \"%s\";\n", keymapConfigFilename);
+				logPrintf("        systemConfigFilename = \"%s\";\n", systemConfigFilename);
+				logPrintf("        resultsDirPath = \"%s\";\n", resultsDirPath);
+				logPrintf("    }\n");
+			}
+
 			reader.getIfPresent("experimentList", experimentList);
 			for (ConfigFiles& files : experimentList) { files.populateEmptyFieldsWithDefaults(defaultExperiment); }
 			if (experimentList.length() == 0) { experimentList.append(defaultExperiment); }

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -520,7 +520,7 @@ void FPSciApp::updateSession(const String& id, bool forceReload) {
 		}
 		// Otherwise let the loaded scene persist
 	}
-	else if (sessConfig->scene != m_loadedScene) {
+	else if (sessConfig->scene != m_loadedScene || forceReload) {
 		loadScene(sessConfig->scene.name);
 		m_loadedScene = sessConfig->scene;
 	}

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -22,18 +22,17 @@ void FPSciApp::onInit() {
 	// Seed random based on the time
 	Random::common().reset(uint32(time(0)));
 
-	// Initialize the app
-	GApp::onInit();
+	GApp::onInit();			// Initialize the G3D application (one time)
+	initExperiment();		// Initialize the experiment
+}
 
+void FPSciApp::initExperiment(){
 	// Load config from files
-	loadConfigs();
+	loadConfigs(startupConfig.experimentList[experimentIdx]);
 	m_lastSavedUser = *currentUser();			// Copy over the startup user for saves
 
 	// Get the size of the primary display
 	displayRes = OSWindow::primaryDisplaySize();						
-
-	// Setup/update waypoint manager
-	waypointManager = WaypointManager::create(this);
 
 	// Setup the display mode
 	setSubmitToDisplayMode(
@@ -42,10 +41,18 @@ void FPSciApp::onInit() {
 		//SubmitToDisplayMode::BALANCE);
 	    //SubmitToDisplayMode::MAXIMIZE_THROUGHPUT);
 
+	// Set the initial simulation timestep to REAL_TIME. The desired timestep is set later.
+	setFrameDuration(frameDuration(), REAL_TIME);
+
+	// Setup/update waypoint manager
+	if (startupConfig.developerMode && startupConfig.waypointEditorMode) {
+		waypointManager = WaypointManager::create(this);
+	}
+
 	// Setup the scene
 	setScene(PhysicsScene::create(m_ambientOcclusion));
 	scene()->registerEntitySubclass("PlayerEntity", &PlayerEntity::create);			// Register the player entity for creation
-	scene()->registerEntitySubclass("FlyingEntity", &FlyingEntity::create);			// Create a target
+	scene()->registerEntitySubclass("FlyingEntity", &FlyingEntity::create);			// Register the target entity for creation
 
 	m_weapon = Weapon::create(&experimentConfig.weapon, scene(), activeCamera());
 	m_weapon->setHitCallback(std::bind(&FPSciApp::hitTarget, this, std::placeholders::_1));
@@ -63,12 +70,9 @@ void FPSciApp::onInit() {
 	showRenderingStats = false;
 	makeGUI();
 
-	updateMouseSensitivity();		// Update (apply) mouse sensitivity
+	updateMouseSensitivity();				// Update (apply) mouse sensitivity
 	const Array<String> sessions = m_userSettingsWindow->updateSessionDropDown();	// Update the session drop down to remove already completed sessions
-	updateSession(sessions[0]);		// Update session to create results file/start collection
-
-	// Set the initial simulation timestep to REAL_TIME. The desired timestep is set later.
-	setFrameDuration(frameDuration(), REAL_TIME);
+	updateSession(sessions[0], true);		// Update session to create results file/start collection
 }
 
 void FPSciApp::toggleUserSettingsMenu() {
@@ -104,13 +108,13 @@ void FPSciApp::saveUserConfig(bool onDiff) {
 	if (sess->logger) {
 		sess->logger->logUserConfig(*currentUser(), sessConfig->id, sessConfig->player.turnScale);
 	}
-	userTable.save(startupConfig.userConfigFilename);
+	userTable.save(startupConfig.experimentList[experimentIdx].userConfigFilename);
 	m_lastSavedUser = *currentUser();			// Copy over this user
 	logPrintf("User table saved.\n");			// Print message to log
 }
 
 void FPSciApp::saveUserStatus(void) {
-	userStatusTable.save(startupConfig.userStatusFilename);
+	userStatusTable.save(startupConfig.experimentList[experimentIdx].userStatusFilename);
 	logPrintf("User status saved.\n");
 }
 
@@ -139,9 +143,9 @@ void FPSciApp::setDirectMode(bool enable) {
 	fpm->setMouseMode(enable ? FirstPersonManipulator::MOUSE_DIRECT : FirstPersonManipulator::MOUSE_DIRECT_RIGHT_BUTTON);
 }
 
-void FPSciApp::loadConfigs() {
+void FPSciApp::loadConfigs(const ConfigFiles& configs) {
 	// Load experiment setting from file
-	experimentConfig = ExperimentConfig::load(startupConfig.experimentConfigFilename);
+	experimentConfig = ExperimentConfig::load(configs.experimentConfigFilename);
 	experimentConfig.printToLog();
 
 	// Get hash for experimentconfig.Any file
@@ -153,11 +157,11 @@ void FPSciApp::loadConfigs() {
 	experimentConfig.getSessionIds(sessionIds);
 
 	// Load per user settings from file
-	userTable = UserTable::load(startupConfig.userConfigFilename);
+	userTable = UserTable::load(configs.userConfigFilename);
 	userTable.printToLog();
 
 	// Load per experiment user settings from file and make sure they are valid
-	userStatusTable = UserStatusTable::load(startupConfig.userStatusFilename);
+	userStatusTable = UserStatusTable::load(configs.userStatusFilename);
 	userStatusTable.printToLog();
 	userStatusTable.validate(sessionIds, userTable.getIds());
 		
@@ -166,11 +170,11 @@ void FPSciApp::loadConfigs() {
 	info.printToLog();										// Print system info to log.txt
 
 	// Get system configuration
-	systemConfig = SystemConfig::load(startupConfig.systemConfigFilename);
+	systemConfig = SystemConfig::load(configs.systemConfigFilename);
 	systemConfig.printToLog();			// Print the latency logger config to log.txt	
 
 	// Load the key binds
-	keyMap = KeyMapping::load(startupConfig.keymapConfigFilename);
+	keyMap = KeyMapping::load(configs.keymapConfigFilename);
 	userInput->setKeyMapping(&keyMap.uiMap);
 }
 
@@ -245,6 +249,7 @@ void FPSciApp::loadModels() {
 	}
 
 	// Create a series of colored materials to choose from for target health
+	m_materials.clear();
 	for (int i = 0; i < m_MatTableSize; i++) {
 		float complete = (float)i / m_MatTableSize;
 		Color3 color = experimentConfig.targetView.healthColors[0] * complete + experimentConfig.targetView.healthColors[1] * (1.0f - complete);
@@ -301,6 +306,7 @@ void FPSciApp::makeGUI() {
 	}
 
 	// Open sub-window buttons here (menu-style)
+	debugPane->removeAllChildren();
 	debugPane->beginRow(); {
 		debugPane->addButton("Render Controls [1]", this, &FPSciApp::showRenderControls);
 		debugPane->addButton("Player Controls [2]", this, &FPSciApp::showPlayerControls);
@@ -309,6 +315,7 @@ void FPSciApp::makeGUI() {
 	}debugPane->endRow();
 
 	// Create the user settings window
+	if (notNull(m_userSettingsWindow)) { removeWidget(m_userSettingsWindow); }
 	m_userSettingsWindow = UserMenu::create(this, userTable, userStatusTable, sessConfig->menu, theme, Rect2D::xywh(0.0f, 0.0f, 10.0f, 10.0f));
 	moveToCenter(m_userSettingsWindow);
 	m_userSettingsWindow->setVisible(true);
@@ -452,7 +459,7 @@ void FPSciApp::initPlayer() {
 	sess->initialHeadingRadians = player->heading();
 }
 
-void FPSciApp::updateSession(const String& id) {
+void FPSciApp::updateSession(const String& id, bool forceReload) {
 	// Check for a valid ID (non-emtpy and 
 	Array<String> ids;
 	experimentConfig.getSessionIds(ids);
@@ -486,7 +493,7 @@ void FPSciApp::updateSession(const String& id) {
 	// Load the experiment scene if we haven't already (target only)
 	if (sessConfig->scene.name.empty()) {
 		// No scene specified, load default scene
-		if (m_loadedScene.empty()) {
+		if (m_loadedScene.empty() || forceReload) {
 			loadScene(m_defaultSceneName);
 			m_loadedScene = m_defaultSceneName;
 		}
@@ -527,14 +534,16 @@ void FPSciApp::updateSession(const String& id) {
 	// Player parameters
 	initPlayer();
 
+	const String resultsDirPath = startupConfig.experimentList[experimentIdx].resultsDirPath;
+
 	// Check for need to start latency logging and if so run the logger now
-	if (!FileSystem::isDirectory(startupConfig.resultsDirPath)) {
-		FileSystem::createDirectory(startupConfig.resultsDirPath);
+	if (!FileSystem::isDirectory(resultsDirPath)) {
+		FileSystem::createDirectory(resultsDirPath);
 	}
 
 	const String logName = sessConfig->logger.logToSingleDb ? 
-		startupConfig.resultsDirPath + experimentConfig.description + "_" + userStatusTable.currentUser + "_" + m_expConfigHash :
-		startupConfig.resultsDirPath + id + "_" + userStatusTable.currentUser + "_" + String(FPSciLogger::genFileTimestamp());
+		resultsDirPath + experimentConfig.description + "_" + userStatusTable.currentUser + "_" + m_expConfigHash :
+		resultsDirPath + id + "_" + userStatusTable.currentUser + "_" + String(FPSciLogger::genFileTimestamp());
 
 	if (systemConfig.hasLogger) {
 		if (!sessConfig->clickToPhoton.enabled) {
@@ -739,7 +748,7 @@ bool FPSciApp::onEvent(const GEvent& event) {
 				foundKey = true;
 			}
 			else if (keyMap.map["reloadConfigs"].contains(ksym)) {
-				loadConfigs();												// (Re)load the configs
+				loadConfigs(startupConfig.experimentList[experimentIdx]);					// (Re)load the configs
 				// Update session from the reloaded configs
 				m_userSettingsWindow->updateSessionDropDown();
 				updateSession(m_userSettingsWindow->selectedSession());
@@ -1414,7 +1423,7 @@ void FPSciApp::onGraphics2D(RenderDevice* rd, Array<shared_ptr<Surface2D>>& pose
 		}
 
 		// Handle recording indicator
-		if (waypointManager->recordMotion) {
+		if (startupConfig.waypointEditorMode && waypointManager->recordMotion) {
 			Draw::point(Point2(rd->viewport().width()*0.9f - 15.0f, 20.0f+m_debugMenuHeight*scale), rd, Color3::red(), 10.0f);
 			outputFont->draw2D(rd, "Recording Position", Point2(rd->viewport().width() - 200.0f , m_debugMenuHeight*scale), 20.0f, Color3::red());
 		}

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -916,6 +916,14 @@ void FPSciApp::onAfterEvents() {
 		updateUserMenu = false;
 	}
 
+	if (reinitExperiment) {			// Check for experiment reinitialization (developer-mode only)
+		m_widgetManager->clear();
+		addWidget(debugWindow);
+		addWidget(developerWindow);
+		initExperiment();
+		reinitExperiment = false;
+	}
+
 	GApp::onAfterEvents();
 }
 

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -83,7 +83,9 @@ protected:
 	/** Called from onInit */
 	void makeGUI();
 	void updateControls(bool firstSession = false);
-	void loadConfigs();
+	
+	void loadConfigs(const ConfigFiles& configs);
+
 	virtual void loadModels();
 	/** Initializes player settings from configs and resets player to initial position 
 		Also updates mouse sensitivity. */
@@ -155,7 +157,9 @@ public:
 	bool		frameToggle			= false;	///< Simple toggle flag used for frame rate click-to-photon monitoring
 	bool		updateUserMenu		= false;	///< Semaphore to indicate user settings needs update
 
-	Vector2 displayRes;
+	int			experimentIdx = 0;				///< Index of the current experiment
+
+	Vector2		displayRes;
 
 	/** Call to change the reticle. */
 	void setReticle(int r);
@@ -172,6 +176,12 @@ public:
 		return m_debugMenuHeight;
 	}
 
+	const Array<String> experimentNames() const {
+		Array<String> names;
+		for (auto config : startupConfig.experimentList) { names.append(config.name); }
+		return names;
+	}
+
     /** callbacks for saving user status and config */
 	void saveUserConfig(bool onDiff);
 	void saveUserConfig() { saveUserConfig(false); }
@@ -183,7 +193,7 @@ public:
 
 	void markSessComplete(String id);
 	/** Updates experiment state to the provided session id and updates player parameters (including mouse sensitivity) */
-	virtual void updateSession(const String& id);
+	virtual void updateSession(const String& id, bool forceReload = false);
 	void updateParameters(int frameDelay, float frameRate);
 	void updateTargetColor(const shared_ptr<TargetEntity>& target);
 	void presentQuestion(Question question);
@@ -200,6 +210,9 @@ public:
 	/** reads current user settings to update sensitivity in the controller */
     void updateMouseSensitivity();
 	
+	/** Initialize an experiment */
+	void initExperiment();
+
 	virtual void onPostProcessHDR3DEffects(RenderDevice *rd) override;
 	virtual void onInit() override;
 	virtual void onAI() override;

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -156,6 +156,7 @@ public:
 	bool		buttonUp			= true;		///< Pass button up to session
 	bool		frameToggle			= false;	///< Simple toggle flag used for frame rate click-to-photon monitoring
 	bool		updateUserMenu		= false;	///< Semaphore to indicate user settings needs update
+	bool		reinitExperiment	= false;	///< Semaphore to indicate experiment needs to be reinitialized
 
 	int			experimentIdx = 0;				///< Index of the current experiment
 

--- a/source/GuiElements.cpp
+++ b/source/GuiElements.cpp
@@ -345,6 +345,15 @@ UserMenu::UserMenu(FPSciApp* app, UserTable& users, UserStatusTable& userStatus,
 	m_ddCurrUserIdx = m_users.getUserIndex(m_userStatus.currentUser);
 	m_expPane = m_parent->addPane("Experiment Settings");
 	m_expPane->setCaptionHeight(40);
+
+	// Only draw experiment selection box in developer mode
+	if (app->startupConfig.developerMode) {
+		m_expPane->beginRow(); {
+			m_expPane->addDropDownList("Experiment", app->experimentNames(), &(app->experimentIdx));
+			m_expPane->addButton("Select Experiment", app, &FPSciApp::initExperiment);
+		} m_expPane->endRow();
+	}
+
 	m_expPane->beginRow(); {
 		m_userDropDown = m_expPane->addDropDownList("User", m_users.getIds(), &m_ddCurrUserIdx);
 		m_expPane->addButton("Select User", this, &UserMenu::updateUserPress);

--- a/source/GuiElements.cpp
+++ b/source/GuiElements.cpp
@@ -350,7 +350,7 @@ UserMenu::UserMenu(FPSciApp* app, UserTable& users, UserStatusTable& userStatus,
 	if (app->startupConfig.developerMode) {
 		m_expPane->beginRow(); {
 			m_expPane->addDropDownList("Experiment", app->experimentNames(), &(app->experimentIdx));
-			m_expPane->addButton("Select Experiment", app, &FPSciApp::initExperiment);
+			m_expPane->addButton("Select Experiment", this, &UserMenu::updateExperimentPress);
 		} m_expPane->endRow();
 	}
 
@@ -555,6 +555,10 @@ void UserMenu::drawUserPane(const MenuConfig& config, UserConfig& user)
 	}
 
 	m_currentUserPane->pack();
+}
+
+void UserMenu::updateExperimentPress() {
+	m_app->reinitExperiment = true;				// Set the reinit semamphore to avoid event handling problems
 }
 
 Array<String> UserMenu::updateSessionDropDown() {

--- a/source/GuiElements.h
+++ b/source/GuiElements.h
@@ -157,6 +157,7 @@ protected:
 	void updateUserPress();
 	void addUserPress();
 	void updateSessionPress();
+	void updateExperimentPress();
 
 public:
 	static shared_ptr<UserMenu> create(FPSciApp* app, UserTable& users, UserStatusTable& userStatus, MenuConfig& config, const shared_ptr<GuiTheme>& theme, const Rect2D& rect) {


### PR DESCRIPTION
This branch adds support for selecting the experiment from an `experimentList` when in developer mode.

The approach is a bit complicated, but should make things easier for users. The only config changes are in the startup config file, which now supports 2 new fields (and drops support for "direct" configuration file specification):

- A `defaultExperiment` which sets up the files to use as defaults for experiment(s) if none are provided, and specifies the only experiment if no `experimentList` is provided
- An `experimentList` which provides a list of (named) experiments as deviations from the `defaultExperiment` provided above

The `defaultExperiment` and `experimentList` entries contain the same file fields that used to exist at the top level of the startup config, namely:

- `experimentConfigFilename`
- `userConfigFilename`
- `userStatusFilename`
- `keymapConfigFilename`
- `systemConfigFilename`
- `resultsDirPath`

In addition to these fields, entries in the `experimentList` also require a `name` field to be provided to make them unique.

When run in developer mode FPSci allows the developer to select from an additional user menu drop-down list of experiments. Otherwise the app (currently) always runs the first experiment in the `experimentList` (or the `defaultExperiment` if no/an empty `experimentList` is provided).

Merging this PR closes #261