### PR TITLE
Remove duplicate insert of playerCamera into scene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,17 @@ data-files/test/userconfig.Any
 "scripts/event logger/software/Logs"
 results/
 # This avoids checking-in experiment-specific files
-data-files/sound
-data-files/scene
-data-files/model
+/data-files/sound/*
+/data-files/scene/*
+/data-files/model/*
+# Included models
+!/data-files/model/sniper
+!/data-files/model/target
+# Included scenes
+!/data-files/scene/Medium_Courtyard.Scene.Any
+!/data-files/scene/Simple_Hallway.Scene.Any
+# Test scene
+!/data-files/scene/Test_Cornell_Box.Scene.Any
 # This stuff ignores any packaged outputs
 *.zip
 *.tar

--- a/data-files/scene/Test_Cornell_Box.Scene.Any
+++ b/data-files/scene/Test_Cornell_Box.Scene.Any
@@ -1,0 +1,114 @@
+
+/* -*- c++ -*- */
+{ 
+    entities = { 
+        box = VisibleEntity { 
+            model = "boxModel"; 
+            frame = Vector3(0, 0, 0 ); 
+        }; 
+        
+        camera = Camera {
+            frame = CFrame::fromXYZYPRDegrees(  0.0f,   1.0f,   6.0f,  0.0f,   0,   0.0f);
+        
+            depthOfFieldSettings = DepthOfFieldSettings {
+                model = "NONE";
+                enabled = false;
+            };
+
+            projection = Projection {
+                nearPlaneZ = -0.1;
+                farPlaneZ = -200;
+                fovDirection = "VERTICAL";
+                fovDegrees = 25;
+            };
+        };
+        
+        customCamera = Camera {
+            frame = CFrame::fromXYZYPRDegrees(  0.5f,   1.5f,   4.0f,  0.0f,   0,   0.0f);
+        
+            depthOfFieldSettings = DepthOfFieldSettings {
+                model = "NONE";
+                enabled = false;
+            };
+
+            projection = Projection {
+                nearPlaneZ = -0.1;
+                farPlaneZ = -200;
+                fovDirection = "VERTICAL";
+                fovDegrees = 25;
+            };
+        };
+        
+        
+        
+        light1 = Light { 
+            bulbPower = Power3(60); 
+            shadowsEnabled = true; 
+            frame = CFrame::fromXYZYPRDegrees(0, 1.92, 0, 0, -90, 0 ); 
+            shadowMapSize = Vector2int16(1024, 1024 ); 
+            spotHalfAngleDegrees = 45; 
+            rectangular = true;
+			extent = Vector2(0.75, 0.75);
+            type = "SPOT"; 
+        }; 
+        
+        light2 = Light { 
+            bulbPower = Power3(60); 
+            shadowsEnabled = true; 
+            frame = CFrame::fromXYZYPRDegrees(0, 1.92, 0, 0, 0, 0 ); 
+            shadowMapSize = Vector2int16(1024, 1024 ); 
+            spotHalfAngleDegrees = 45; 
+            rectangular = true; 
+			extent = Vector2(0.75, 0.75);
+            type = "SPOT"; 
+        }; 
+        
+        light3 = Light { 
+            bulbPower = Power3(60); 
+            shadowsEnabled = true; 
+            frame = CFrame::fromXYZYPRDegrees(0, 1.92, 0, 90, 0, 0 ); 
+            shadowMapSize = Vector2int16(1024, 1024 ); 
+            spotHalfAngleDegrees = 45; 
+            rectangular = true; 
+			extent = Vector2(0.75, 0.75);
+            type = "SPOT"; 
+        }; 
+        
+        light4 = Light { 
+            bulbPower = Power3(60); 
+            shadowsEnabled = true; 
+            frame = CFrame::fromXYZYPRDegrees(0, 1.92, 0, -90, 0, 0 ); 
+            shadowMapSize = Vector2int16(1024, 1024 ); 
+            spotHalfAngleDegrees = 45; 
+            rectangular = true; 
+			extent = Vector2(0.75, 0.75);
+            type = "SPOT"; 
+        }; 
+        
+        light5 = Light { 
+            bulbPower = Power3(60); 
+            shadowsEnabled = true; 
+            frame = CFrame::fromXYZYPRDegrees(0, 1.92, 0, 180, 0, 180 ); 
+            shadowMapSize = Vector2int16(1024, 1024 ); 
+			extent = Vector2(0.75, 0.75);
+            spotHalfAngleDegrees = 45; 
+            rectangular = true; 
+            type = "SPOT"; 
+        }; 
+        
+    }; 
+    
+	lightingEnvironment = LightingEnvironment {
+		environmentMap = 0.05; 
+	}; 
+    
+    models = { 
+        boxModel = ArticulatedModel::Specification { 
+            filename = "model/CornellBox/CornellBox.zip/CornellBox-Empty-CO.obj"; 
+        }; 
+        
+    }; 
+    
+    name = "FPSci Test Cornell Box (Empty CO)"; 
+    
+} 

--- a/data-files/test/experimentconfig.Any
+++ b/data-files/test/experimentconfig.Any
@@ -49,15 +49,15 @@
             id = "defaultCamera";
             trials = ( { ids = ( "small"); count = 1; } );
             scene = {
-                name = "G3D Sponza"; 
+                name = "FPSci Test Cornell Box (Empty CO)"; 
             };
         },
         {
             id = "customCamera";
             trials = ( { ids = ( "small"); count = 1; } );
             scene = {
-                name = "G3D Sponza";
-                playerCamera = "lionCamera";
+                name = "FPSci Test Cornell Box (Empty CO)";
+                playerCamera = "customCamera";
             };
         }
     );

--- a/data-files/test/experimentconfig.Any
+++ b/data-files/test/experimentconfig.Any
@@ -44,6 +44,21 @@
                     count = 5;
                 }
             );
+        },
+        {
+            id = "defaultCamera";
+            trials = ( { ids = ( "small"); count = 1; } );
+            scene = {
+                name = "G3D Sponza"; 
+            };
+        },
+        {
+            id = "customCamera";
+            trials = ( { ids = ( "small"); count = 1; } );
+            scene = {
+                name = "G3D Sponza";
+                playerCamera = "lionCamera";
+            };
         }
     );
 

--- a/docs/scene.md
+++ b/docs/scene.md
@@ -7,8 +7,8 @@ In addition to the base `.scene.any` file, the following fields must/can be prov
 ### Physics
 Two "physics-based" parameters are also provided by the scene file in their own `Physics` header, these are:
 
-* `minHeight` - A height at which the player is respawned (at their spawn location) if the fall below
-* `gravity` - Currently unused...
+* `minHeight` - A height at which the player respawns (at their spawn location) if they fall below
+* `gravity` - Deprecated. Currently ignored...
 
 An example of this configuration (from within the top-level of a `scene.Any` file) is provided below:
 
@@ -38,9 +38,9 @@ player = PlayerEntity {
 ```
 
 ### Player Camera
-The player camera may be specified as with any other camera in a `scene.any` file, but is required to have the name `playerCamera` as it's name to specify it as the camera used for the player view. If no player camera is provided in the scene file, but a `PlayerEntity` is provided, the application creates the player camera from the player entity.
+Any camera specified in the scene can be used as the camera attached to the player. This mapping is done by putting the name of the chosen camera in the [FPSci scene settings](./general_config.md#scene-settings). If no name is specified, the `defaultCamera` will be used.
 
-The player camera is a way to modify camera properties for the player view, excluding the following properties which are overriden in the application:
+The player camera is a way to modify camera properties for the player view, excluding the following properties which are overridden in the application:
 
 * Anti-aliasing
 * Bloom strength

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -507,15 +507,15 @@ void FPSciApp::updateSession(const String& id) {
 	// Load the experiment scene if we haven't already (target only)
 	if (sessConfig->scene.name.empty()) {
 		// No scene specified, load default scene
-		if (m_loadedScene.empty()) {
+		if (m_loadedScene.name.empty()) {
 			loadScene(m_defaultSceneName);
-			m_loadedScene = m_defaultSceneName;
+			m_loadedScene.name = m_defaultSceneName;
 		}
 		// Otherwise let the loaded scene persist
 	}
-	else if (sessConfig->scene.name != m_loadedScene) {
+	else if (sessConfig->scene != m_loadedScene) {
 		loadScene(sessConfig->scene.name);
-		m_loadedScene = sessConfig->scene.name;
+		m_loadedScene = sessConfig->scene;
 	}
 
 	// Check for play mode specific parameters

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -617,7 +617,6 @@ void FPSciApp::onAfterLoadScene(const Any& any, const String& sceneName) {
 	const String pcamName = sessConfig->scene.playerCamera;
 	playerCamera = pcamName.empty() ? scene()->defaultCamera() : scene()->typedEntity<Camera>(sessConfig->scene.playerCamera);
 	alwaysAssertM(notNull(playerCamera), format("Scene %s does not contain a camera named \"%s\"!", sessConfig->scene.name, sessConfig->scene.playerCamera));
-	scene()->insert((shared_ptr<Entity>)playerCamera);
 	setActiveCamera(playerCamera);
 
 	initPlayer();

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -56,7 +56,7 @@ protected:
 	RealTime								m_lastJumpTime = 0.0f;				///< Time of last jump
 
 	int										m_lastUniqueID = 0;					///< Counter for creating unique names for various entities
-	String									m_loadedScene = "";
+	SceneConfig								m_loadedScene;						///< Configuration for loaded scene
 	String									m_defaultSceneName = "FPSci Simple Hallway";	// Default scene to load
 
 	String									m_expConfigHash;					///< String hash of experiment config file

--- a/tests/FPSciTests.cpp
+++ b/tests/FPSciTests.cpp
@@ -546,3 +546,16 @@ TEST_F(FPSciTests, TestTargetSizes) {
 	float targettoolargesize = 8.0f;
 	EXPECT_NEAR(toolargesize, targettoolargesize, targettoolargesize * e);
 }
+
+
+TEST_F(FPSciTests, TestCameraSelection) {
+
+	SelectSession("defaultCamera");
+	s_app->oneFrame();
+	EXPECT_TRUE(s_app->playerCamera->name() == "defaultCamera");
+
+	SelectSession("customCamera");
+	s_app->oneFrame();
+	EXPECT_TRUE(s_app->playerCamera->name() == "lionCamera");
+
+}

--- a/tests/FPSciTests.cpp
+++ b/tests/FPSciTests.cpp
@@ -552,10 +552,10 @@ TEST_F(FPSciTests, TestCameraSelection) {
 
 	SelectSession("defaultCamera");
 	s_app->oneFrame();
-	EXPECT_TRUE(s_app->playerCamera->name() == "defaultCamera");
+	EXPECT_TRUE(s_app->playerCamera->name() == "camera");
 
 	SelectSession("customCamera");
 	s_app->oneFrame();
-	EXPECT_TRUE(s_app->playerCamera->name() == "lionCamera");
+	EXPECT_TRUE(s_app->playerCamera->name() == "customCamera");
 
 }

--- a/vs/FPSci.test.vcxproj
+++ b/vs/FPSci.test.vcxproj
@@ -66,6 +66,7 @@
     <ClInclude Include="..\tests\TestFakeInput.h" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\data-files\scene\Test_Cornell_Box.Scene.Any" />
     <None Include="..\data-files\test\experimentconfig.Any" />
     <None Include="..\data-files\test\keymap.Any" />
     <None Include="..\data-files\test\startupconfig.Any" />

--- a/vs/FPSci.test.vcxproj.filters
+++ b/vs/FPSci.test.vcxproj.filters
@@ -29,6 +29,9 @@
     <None Include="..\data-files\test\systemconfig.Any">
       <Filter>Config Files</Filter>
     </None>
+    <None Include="..\data-files\scene\Test_Cornell_Box.Scene.Any">
+      <Filter>Config Files</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Config Files">


### PR DESCRIPTION
This branch fixes a bug from `FPSciApp::onAfterLoadScene()` wherein the `playerCamera` was being inserted into the scene after the scene is loaded (which already inserts the camera). This exception only showed up when running the application in the `Debug` configuration, and was ignore-able, but caused confusion for some developers.

Merging this PR closes #264.