### PR TITLE
Moves weapon firing to onSimulation

### DIFF
--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -43,7 +43,7 @@ void FPSciApp::initExperiment(){
 
 	// Set the initial simulation timestep to REAL_TIME. The desired timestep is set later.
 	setFrameDuration(frameDuration(), REAL_TIME);
-	m_lastOnSimulationRealTime = System::time();
+	m_lastOnSimulationRealTime = 0.0;
 
 	// Setup/update waypoint manager
 	if (startupConfig.developerMode && startupConfig.waypointEditorMode) {
@@ -687,9 +687,16 @@ void FPSciApp::onGraphics3D(RenderDevice* rd, Array<shared_ptr<Surface> >& surfa
 }
 
 void FPSciApp::onSimulation(RealTime rdt, SimTime sdt, SimTime idt) {
-	// Set up the shot(s)
 	// TODO: this should eventually probably use sdt instead of rdt
-	RealTime currentRealTime = m_lastOnSimulationRealTime + rdt;
+	RealTime currentRealTime;
+	if (m_lastOnSimulationRealTime == 0) {
+		m_lastOnSimulationRealTime = System::time();			// Grab the current system time if uninitialized
+		currentRealTime = m_lastOnSimulationRealTime;			// Set this equal to the current system time
+	}
+	else {
+		currentRealTime = m_lastOnSimulationRealTime + rdt;		// Increment the time by the current real time delta
+	}
+
 	bool stateCanFire = sess->currentState == PresentationState::trialTask && !m_userSettingsWindow->visible();
 
 	// These variables will be used to fire after the various weapon styles populate them below

--- a/source/FPSciApp.cpp
+++ b/source/FPSciApp.cpp
@@ -746,7 +746,7 @@ void FPSciApp::onSimulation(RealTime rdt, SimTime sdt, SimTime idt) {
 		if (isNull(target)) // Miss case
 		{
 			// Play scene hit sound
-			if (!sessConfig->weapon.isContinuous()) {
+			if (!weapon->config()->isContinuous()) {
 				m_sceneHitSound->play(sessConfig->audio.sceneHitSoundVol);
 			}
 		}
@@ -755,6 +755,7 @@ void FPSciApp::onSimulation(RealTime rdt, SimTime sdt, SimTime idt) {
 	if (shotFired) {
 		weapon->setLastFireTime(newLastFireTime);
 	}
+	weapon->playSound(shotFired, shootButtonUp);
 
 	// TODO (or NOTTODO): The following can be cleared at the cost of one more level of inheritance.
 	sess->onSimulation(rdt, sdt, idt);
@@ -1136,7 +1137,7 @@ void FPSciApp::drawHUD(RenderDevice *rd) {
 	// Scale is used to position/resize the "score banner" when the window changes size in "windowed" mode (always 1 in fullscreen mode).
 	const Vector2 scale = rd->viewport().wh() / displayRes;
 
-	RealTime now = System::time();
+	RealTime now = m_lastOnSimulationRealTime;
 
 	// Weapon ready status (cooldown indicator)
 	if (sessConfig->hud.renderWeaponStatus) {
@@ -1499,7 +1500,7 @@ void FPSciApp::onGraphics2D(RenderDevice* rd, Array<shared_ptr<Surface2D>>& pose
 		if (activeCamera() == playerCamera) {
 			// Reticle
 			const shared_ptr<UserConfig> user = currentUser();
-			float tscale = weapon->cooldownRatio(System::time(), user->reticleChangeTimeS);
+			float tscale = weapon->cooldownRatio(m_lastOnSimulationRealTime, user->reticleChangeTimeS);
 			float rScale = tscale * user->reticleScale[0] + (1.0f - tscale)*user->reticleScale[1];
 			Color4 rColor = user->reticleColor[1] * (1.0f - tscale) + user->reticleColor[0] * tscale;
 			Draw::rect2D(((reticleTexture->rect2DBounds() - reticleTexture->vector2Bounds() / 2.0f))*rScale / 2.0f + rd->viewport().wh() / 2.0f, rd, rColor, reticleTexture);

--- a/source/FPSciApp.h
+++ b/source/FPSciApp.h
@@ -47,13 +47,19 @@ protected:
 	Table<String, Array<shared_ptr<ArticulatedModel>>> m_explosionModels;
 
 	/** Used for visualizing history of frame times. Temporary, awaiting a G3D built-in that does this directly with a texture. */
-	Queue<float>							m_frameDurationQueue;				///< Queue for history of frrame times
+	Queue<float>							m_frameDurationQueue;				///< Queue for history of frame times
 
 	/** Used to detect GUI changes to m_reticleIndex */
 	int										m_lastReticleLoaded = -1;			///< Last loaded reticle (used for change detection)
 	float									m_debugMenuHeight = 0.0f;			///< Height of the debug menu when in developer mode
 
 	RealTime								m_lastJumpTime = 0.0f;				///< Time of last jump
+public:
+	RealTime								m_lastOnSimulationRealTime = 0.0f;	///< Wall clock time last onSimulation finished
+	SimTime									m_lastOnSimulationSimTime = 0.0f;	///< Simulation time last onSimulation finished
+	SimTime									m_lastOnSimulationIdealSimTime = 0.0f;	///< Ideal simulation time last onSimulation finished
+protected:
+	float									m_currentWeaponDamage = 0.0f;		///< A hack to avoid passing damage through callbacks
 
 	int										m_lastUniqueID = 0;					///< Counter for creating unique names for various entities
 	SceneConfig								m_loadedScene;						///< Configuration for loaded scene
@@ -154,8 +160,11 @@ public:
 	float		lastSetFrameRate	= 0.0f;		///< Last set frame rate
 	const int	numReticles			= 55;		///< Total count of reticles available to choose from
 	float		sceneBrightness		= 1.0f;		///< Scene brightness scale factor
+	
+	bool		shootButtonUp			= true;	///< Tracks shoot button state (used for click indicator)
+	bool		shootButtonJustReleased = false;///< Tracks shoot button state (used for weapon timing)
+	bool		shootButtonJustPressed = false;	///< Tracks shoot button state (used for weapon timing)
 
-	bool		buttonUp			= true;		///< Tracks shoot button state (used for click indicator)
 	bool		frameToggle			= false;	///< Simple toggle flag used for frame rate click-to-photon monitoring
 	bool		updateUserMenu		= false;	///< Semaphore to indicate user settings needs update
 	bool		reinitExperiment	= false;	///< Semaphore to indicate experiment needs to be reinitialized

--- a/source/Session.cpp
+++ b/source/Session.cpp
@@ -262,7 +262,7 @@ void Session::updatePresentationState()
 		if (m_config->player.stillBetweenTrials) {
 			m_player->setMoveEnable(false);
 		}
-		if (!(m_app->buttonUp && m_config->timing.clickToStart)) {
+		if (!(m_app->shootButtonUp && m_config->timing.clickToStart)) {
 			newState = PresentationState::trialFeedback;
 		}
 	}
@@ -362,7 +362,7 @@ void Session::updatePresentationState()
 	}
 	else if (currentState == PresentationState::sessionFeedback) {
 		if (m_hasSession) {
-			if (stateElapsedTime > m_config->timing.sessionFeedbackDuration && (!m_config->timing.sessionFeedbackRequireClick || !m_app->buttonUp)) {
+			if (stateElapsedTime > m_config->timing.sessionFeedbackDuration && (!m_config->timing.sessionFeedbackRequireClick || !m_app->shootButtonUp)) {
 				newState = PresentationState::complete;
         
 				// Save current user config and status

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -87,7 +87,7 @@ void Weapon::onPose(Array<shared_ptr<Surface> >& surface) {
 		const float zScale = -yScale * 0.5f;
 		float kick = 0.f;
 		// ratio from start to end of kick from 0 to 1
-		const float kickRatio = cooldownRatio(m_config->kickDuration);
+		const float kickRatio = cooldownRatio(System::time(), m_config->kickDuration);
 		kick = m_config->kickAngleDegrees * sinf(kickRatio * pif());
 		const float lookY = m_camera->frame().lookVector().y - 6.f * sin(2 * pif() / 360.0f * kick);
 		m_frame = m_camera->frame() * CFrame::fromXYZYPRDegrees(0.3f, -0.4f + lookY * yScale, -1.1f + lookY * zScale, 10, 5+kick);
@@ -217,7 +217,7 @@ shared_ptr<TargetEntity> Weapon::fire(
 	bool dummyShot)
 {
 	static RealTime lastTime;
-	m_lastFireAt = System::time();						// Capture the time
+	m_lastFireTime = System::time();						// Capture the time
 
 	Ray ray = m_camera->frame().lookRay();		// Use the camera lookray for hit detection
 	float spread = m_config->fireSpreadDegrees * 2.f * pif() / 360.f;
@@ -308,7 +308,7 @@ shared_ptr<TargetEntity> Weapon::fire(
 		}
 	}
 
-	// If we're not in laser mode play the sounce (once) here
+	// If we're not in laser mode play the sound (once) here
 	if (!m_config->isContinuous()) {
 		m_fireSound->play(m_config->fireSoundVol);
 		//m_fireSound->play(activeCamera()->frame().translation, activeCamera()->frame().lookVector() * 2.0f, 0.5f);
@@ -329,16 +329,32 @@ void Weapon::setFiring(bool firing = true) {
 	m_firing = firing;
 }
 
-bool Weapon::canFire() const {
+void Weapon::setLastFireTime(RealTime lastFireTime) {
+	m_lastFireTime = lastFireTime;
+}
+
+RealTime Weapon::fireDurationUntil(RealTime currentTime) {
+	return currentTime - m_lastFireTime;
+}
+
+int Weapon::numShotsUntil(RealTime currentTime) {
+	return max((int)floorf((float)(currentTime - m_lastFireTime) / m_config->firePeriod), 0);
+}
+
+bool Weapon::canFire(RealTime now) const {
 	if (isNull(m_config)) return true;
-	return (System::time() - m_lastFireAt) > m_config->firePeriod;
+	return (now - m_lastFireTime) > m_config->firePeriod;
 }
 
-float Weapon::cooldownRatio() const {
+float Weapon::cooldownRatio(RealTime now) const {
 	if (isNull(m_config) || m_config->firePeriod == 0.0) return 1.0f;
-	return cooldownRatio(m_config->firePeriod);
+	return cooldownRatio(now, m_config->firePeriod);
 }
 
-float Weapon::cooldownRatio(float duration) const {
-	return clamp((float)(System::time() - m_lastFireAt) / duration, 0.0f, 1.0f);
+float Weapon::cooldownRatio(RealTime now, float duration) const {
+	return clamp((float)(now - m_lastFireTime) / duration, 0.0f, 1.0f);
+}
+
+float Weapon::damagePerShot() const {
+	return m_config->damagePerSecond * m_config->firePeriod;
 }

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -87,7 +87,6 @@ protected:
 	RealTime						m_lastFireTime;						///< The time of the last fire event up to which time damage has been applied
 
 	bool							m_scoped = false;					///< Flag used for scope management
-	bool							m_firing = false;					///< Flag used for auto fire management
 
 	shared_ptr<Scene>				m_scene;							///< Scene for weapon
 	shared_ptr<Camera>				m_camera;							///< Camera for weapon
@@ -149,8 +148,6 @@ public:
 		Array<shared_ptr<Entity>>& dontHit,
 		bool dummyShot);
 
-	// Saves state to weaponand starts or stops fire audio playback
-	void setFiring(bool firing);
 	// Records provided lastFireTime 
 	void setLastFireTime(RealTime lastFireTime);
 	// Computes duration from last fire time until given currentTime
@@ -165,6 +162,8 @@ public:
 		if (notNull(m_fireAudio)) { m_fireAudio->stop(); }
 		m_fireSound = Sound::create(System::findDataFile(m_config->fireSound), m_config->isContinuous());
 	}
+	// Plays the sound based on the weapon fire mode
+	void playSound(bool shotFired, bool shootButtonUp);
 	
 	void setHitCallback(std::function<void(shared_ptr<TargetEntity>)> callback) { m_hitCallback = callback; }
 	void setMissCallback(std::function<void(void)> callback) { m_missCallback = callback; }
@@ -181,5 +180,4 @@ public:
 	void loadModels();
 
 	bool scoped() { return m_scoped;  }
-	bool firing() { return m_firing; }
 };

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -69,9 +69,7 @@ public:
 class Weapon : Entity {
 protected:
 	Weapon(WeaponConfig* config, shared_ptr<Scene>& scene, shared_ptr<Camera>& cam) :
-		m_config(config), m_scene(scene), m_camera(cam), m_ammo(config->maxAmmo) {
-		m_lastFireTime = System::time();
-	};
+		m_config(config), m_scene(scene), m_camera(cam), m_ammo(config->maxAmmo) {};
 
 	shared_ptr<ArticulatedModel>    m_viewModel;						///< Model for the weapon
 	shared_ptr<ArticulatedModel>    m_bulletModel;						///< Model for the "bullet"
@@ -84,7 +82,7 @@ protected:
 	int								m_lastBulletId = 0;					///< Bullet ID (auto incremented)
 	int								m_ammo;								///< Remaining ammo
 
-	RealTime						m_lastFireTime;						///< The time of the last fire event up to which time damage has been applied
+	RealTime						m_lastFireTime = 0;					///< The time of the last fire event up to which time damage has been applied
 
 	bool							m_scoped = false;					///< Flag used for scope management
 

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -70,7 +70,7 @@ class Weapon : Entity {
 protected:
 	Weapon(WeaponConfig* config, shared_ptr<Scene>& scene, shared_ptr<Camera>& cam) :
 		m_config(config), m_scene(scene), m_camera(cam), m_ammo(config->maxAmmo) {
-		m_lastFireAt = System::time();
+		m_lastFireTime = System::time();
 	};
 
 	shared_ptr<ArticulatedModel>    m_viewModel;						///< Model for the weapon
@@ -82,8 +82,9 @@ protected:
 	Array<shared_ptr<Projectile>>	m_projectiles;						///< Arrray of drawn projectiles
 
 	int								m_lastBulletId = 0;					///< Bullet ID (auto incremented)
-	RealTime						m_lastFireAt;						///< Last fire time
 	int								m_ammo;								///< Remaining ammo
+
+	RealTime						m_lastFireTime;						///< The time of the last fire event up to which time damage has been applied
 
 	bool							m_scoped = false;					///< Flag used for scope management
 	bool							m_firing = false;					///< Flag used for auto fire management
@@ -91,8 +92,8 @@ protected:
 	shared_ptr<Scene>				m_scene;							///< Scene for weapon
 	shared_ptr<Camera>				m_camera;							///< Camera for weapon
 
-	std::function<void(shared_ptr<TargetEntity>)> m_hitCallback;
-	std::function<void(void)> m_missCallback;
+	std::function<void(shared_ptr<TargetEntity>)> m_hitCallback;		///< This is set to FPSciApp::hitTarget
+	std::function<void(void)> m_missCallback;							///< This is set to FPSciApp::missEvent
 
 	int										m_lastDecalID = 0;
 	shared_ptr<ArticulatedModel>			m_missDecalModel;					///< Model for the miss decal
@@ -108,18 +109,24 @@ public:
 		return createShared<Weapon>(config, scene, cam);
 	};
 
-	void resetCooldown() { m_lastFireAt = 0; }
-	bool canFire() const;
+	//virtual void onSimulation(SimTime absoluteTime, SimTime deltaTime) override;
+
+	void resetCooldown() { m_lastFireTime = 0; }
+	bool canFire(RealTime now) const;
 	/** 
 		Returns a value between 0 and 1 that is the difference between 
 		now and the last fire time over the weapon cooldown period
 	*/
-	float cooldownRatio() const;
+	float cooldownRatio(RealTime now) const;
 	/** 
 		Returns a value between 0 and 1 that is the difference between 
 		now and the last fire time over the duration
 	*/
-	float cooldownRatio(float duration) const;
+	float cooldownRatio(RealTime now, float duration) const;
+	/**
+		Returns the damage per shot 
+	*/
+	float damagePerShot() const;
 	const WeaponConfig* config() const { return m_config; }
 
 	int remainingAmmo() const { 
@@ -142,8 +149,14 @@ public:
 		Array<shared_ptr<Entity>>& dontHit,
 		bool dummyShot);
 
-	// Saves state to weapon and starts or stops fire audio playback
+	// Saves state to weaponand starts or stops fire audio playback
 	void setFiring(bool firing);
+	// Records provided lastFireTime 
+	void setLastFireTime(RealTime lastFireTime);
+	// Computes duration from last fire time until given currentTime
+	RealTime fireDurationUntil(RealTime currentTime);
+	// Computes an integer number of shots that can happen until given currentTime
+	int numShotsUntil(RealTime currentTime);
 
 	void onPose(Array<shared_ptr<Surface> >& surface);
 

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -112,6 +112,7 @@ public:
 
 	void resetCooldown() { m_lastFireTime = 0; }
 	bool canFire(RealTime now) const;
+	RealTime lastFireTime() { return m_lastFireTime; }
 	/** 
 		Returns a value between 0 and 1 that is the difference between 
 		now and the last fire time over the weapon cooldown period

--- a/tests/FPSciTests.cpp
+++ b/tests/FPSciTests.cpp
@@ -581,8 +581,8 @@ TEST_F(FPSciTests, TestWeapon60HzContinuous) {
 	s_app->oneFrame();
 	s_fakeInput->window().injectMouseUp(0);
 	s_app->oneFrame();
-	EXPECT_NEAR(end - start, 1, 0.017) << "Failed to be within a frame period of the expected end time!";
-	ASSERT_NEAR(numFrames, 60, 1) << "Wrong number of frames taken.";
+	EXPECT_NEAR(end - start, 1, 0.034) << "Failed to be within 2 frame periods of the expected end time!";
+	ASSERT_NEAR(numFrames, 60, 2) << "Wrong number of frames taken.";
 }
 
 TEST_F(FPSciTests, TestWeapon30HzContinuous) {
@@ -605,7 +605,7 @@ TEST_F(FPSciTests, TestWeapon30HzContinuous) {
 	s_app->oneFrame();
 	s_fakeInput->window().injectMouseUp(0);
 	s_app->oneFrame();
-	EXPECT_NEAR(end - start, 1, 0.034) << "Failed to be within a frame of the expected end time!";
+	EXPECT_NEAR(end - start, 1, 0.067) << "Failed to be within 2 frames of the expected end time!";
 	ASSERT_NEAR(numFrames, 30, 1) << "Wrong number of frames taken.";
 }
 
@@ -701,8 +701,8 @@ TEST_F(FPSciTests, TestWeapon60Hz33ms) {
 	s_app->oneFrame();
 	s_fakeInput->window().injectMouseUp(0);
 	s_app->oneFrame();
-	EXPECT_NEAR(end - start, 1, 0.033) << "Failed to be within a firePeriod of the expected end time!";
-	ASSERT_NEAR(numFrames, 60, 33/17) << "Wrong number of frames taken.";
+	EXPECT_NEAR(end - start, 1, 0.034) << "Failed to be within a firePeriod of the expected end time!";
+	ASSERT_NEAR(numFrames, 60, 34/17) << "Wrong number of frames taken.";
 }
 
 TEST_F(FPSciTests, TestWeapon60Hz16ms) {
@@ -712,16 +712,16 @@ TEST_F(FPSciTests, TestWeapon60Hz16ms) {
 	s_app->oneFrame();
 	auto spawnedtargets = respawnTargets();
 	ASSERT_EQ(spawnedtargets, 1);
-	s_app->oneFrame();
+	shared_ptr<TargetEntity> target = s_app->sess->targetArray()[0];
 	s_fakeInput->window().injectMouseDown(0);
 	int numFrames = 0;
 	RealTime start = System::time();
-	while (s_app->sess->targetArray().length() > 0 && System::time() - start < 2.f) {
+	while (target->health() > 0.f && System::time() - start < 2.f) {
 		s_app->oneFrame();
 		numFrames++;
 	}
 	RealTime end = System::time();
-	EXPECT_TRUE(s_app->sess->targetArray().length() == 0) << "Target should be destroyed!";
+	EXPECT_LE(target->health(), 0.f) << "Target should be destroyed!";
 	s_app->oneFrame();
 	s_fakeInput->window().injectMouseUp(0);
 	s_app->oneFrame();


### PR DESCRIPTION
In #269 the new tests don't yet pass, and it made sense to do a rather large restructuring of the code around weapon firing. This pull request moves the weapon firing into `onSimulation` instead of `onUserInput` so that it can be decoupled.

In its current state, this partly works, but it still doesn't pass all the tests, and there's likely some additional issues still present. I'm creating another pull request into the main PR in case this path ends up being unproductive and we decide to do something else.