### PR TITLE
Startup config loading

### DIFF
--- a/source/ConfigFiles.h
+++ b/source/ConfigFiles.h
@@ -105,6 +105,14 @@ public:
 	
 	bool	audioEnable = true;									///< Audio on/off
 
+	static StartupConfig load(const String& filename) {
+		StartupConfig config;
+		if (!FileSystem::exists(filename)) {
+			config.toAny(true).save(filename);		// If the file doesn't exist create it
+		}
+		return Any::fromFile(filename);				// Load back from the Any file
+	}
+
 	StartupConfig() {};
 
 	/** Construct from any here */

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -6,14 +6,8 @@
 G3D_START_AT_MAIN();
 
 int main(int argc, const char* argv[]) {
-	if (FileSystem::exists("startupconfig.Any")) {
-		FPSciApp::startupConfig = Any::fromFile("startupconfig.Any");
-	}
-	else {
-		// autogenerate if it wasn't there (force all fields into this any file)
-		FPSciApp::startupConfig.toAny(true).save("startupconfig.Any");
-	}
 
+	FPSciApp::startupConfig = StartupConfig::load("startupconfig.Any");
 
 	{
 		G3DSpecification spec;


### PR DESCRIPTION
This branch introduces a `StartupConfig::load()` static method that handles checking for a valid startup config, creating one if not available, then returning the resulting object. This solves the issue of an exception at startup when running without a valid `startupconfig.Any` file in the `data-files` directory (i.e. when a new `startupconfig.Any` is created).

Merging this PR closes #277.